### PR TITLE
fix: resolve build errors and add route-based code-splitting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from 'react';
 import { Route, Routes, Navigate } from 'react-router-dom';
 
 // Providers (Global State)
@@ -5,49 +6,55 @@ import { AuthProvider } from './features/auth/AuthContext';
 import { ShiftProvider } from './features/shifts/ShiftContext';
 import { ThemeProvider } from './app/providers/ThemeContext';
 
-// App Pages & Layout
+// App Shell (eager — it is the persistent frame around every page).
 import { AppShell } from './app/layout/AppShell';
-import { HomePage } from './app/layout/HomePage';
-import { LoginPage } from './features/auth/LoginPage';
-import { OverviewPage } from './features/overview/OverviewPage';
-import { AdminPage } from './features/admin/AdminPage';
-import MyShiftsPage from './features/shifts/MyShiftsPage';
-import SettingsPage from './features/settings/SettingsPage';
-
 import { RoleGuard } from './features/auth/RoleGuards';
+import { PageLoader } from './shared/components/PageLoader';
 
 /**
  * --- MAIN APP COMPONENT ---
  * This file handles the top-level structure of the application.
- * 
+ *
  * Logic:
  * 1. Wraps everything in the necessary Providers (Auth, Shift, Theme).
  * 2. Defines the main Routes for navigation.
+ * 3. Lazy-loads each page so the initial bundle only ships what the
+ *    current route needs (code-splitting).
  */
+
+// Lazy page chunks. Named exports are mapped to a `default` for React.lazy.
+const HomePage = lazy(() => import('./app/layout/HomePage').then((m) => ({ default: m.HomePage })));
+const LoginPage = lazy(() => import('./features/auth/LoginPage').then((m) => ({ default: m.LoginPage })));
+const OverviewPage = lazy(() => import('./features/overview/OverviewPage').then((m) => ({ default: m.OverviewPage })));
+const AdminPage = lazy(() => import('./features/admin/AdminPage').then((m) => ({ default: m.AdminPage })));
+const MyShiftsPage = lazy(() => import('./features/shifts/MyShiftsPage'));
+const SettingsPage = lazy(() => import('./features/settings/SettingsPage'));
 
 export default function App() {
   return (
     <ThemeProvider>
       <AuthProvider>
         <ShiftProvider>
-          <Routes>
-            {/* 1. PUBLIC ROUTES: Available to everyone. */}
-            <Route path="/login" element={<LoginPage />} />
+          <Suspense fallback={<PageLoader />}>
+            <Routes>
+              {/* 1. PUBLIC ROUTES: Available to everyone. */}
+              <Route path="/login" element={<LoginPage />} />
 
-            {/* 2. PROTECTED ROUTES: Only for logged-in users. */}
-            <Route path="/" element={<AppShell />}>
-              <Route index element={<HomePage />} />
-              <Route path="overview" element={<OverviewPage />} />
-              <Route path="my-shifts" element={<MyShiftsPage />} />
-              <Route element={<RoleGuard />}>
-                <Route path="admin" element={<AdminPage />} />
+              {/* 2. PROTECTED ROUTES: Only for logged-in users. */}
+              <Route path="/" element={<AppShell />}>
+                <Route index element={<HomePage />} />
+                <Route path="overview" element={<OverviewPage />} />
+                <Route path="my-shifts" element={<MyShiftsPage />} />
+                <Route element={<RoleGuard />}>
+                  <Route path="admin" element={<AdminPage />} />
+                </Route>
+                <Route path="settings" element={<SettingsPage />} />
               </Route>
-              <Route path="settings" element={<SettingsPage />} />
-            </Route>
 
-            {/* 3. FALLBACK: Redirect any unknown URL to Home. */}
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Routes>
+              {/* 3. FALLBACK: Redirect any unknown URL to Home. */}
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
+          </Suspense>
         </ShiftProvider>
       </AuthProvider>
     </ThemeProvider>

--- a/src/app/layout/AppShell.tsx
+++ b/src/app/layout/AppShell.tsx
@@ -33,7 +33,7 @@ export interface AppOutletContext {
 
 export function AppShell() {
   const { user, isAuthChecking, isLoading: isAuthLoading } = useAuthContext();
-  const { activeShift, allActiveShifts, locations, isLoading: isShiftsLoading, selectedLocationId, setSelectedLocationId } = useShiftContext();
+  const { activeShift, allActiveShifts, locations, selectedLocationId, setSelectedLocationId } = useShiftContext();
 
   // Location switch/confirm logic hook.
   const { isLocationPopupOpen, setIsLocationPopupOpen, pendingLocation, handleLocationSelect } = useLocationManagement({

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { UserIcon, BellIcon, ShieldCheckIcon, PaletteIcon, CaretRightIcon } from "@phosphor-icons/react";
+import { UserIcon, BellIcon, ShieldCheckIcon, PaletteIcon, CaretRightIcon, type Icon } from "@phosphor-icons/react";
 import { useAuthContext } from "@features/auth/AuthContext";
 import { useTheme } from "@app/providers/ThemeContext";
 
@@ -7,11 +7,23 @@ import { useTheme } from "@app/providers/ThemeContext";
  * Unified style with the rest of the app.
  */
 
+interface SettingItem {
+  name: string;
+  icon: Icon;
+  detail?: string;
+  action?: () => void;
+}
+
+interface SettingSection {
+  title: string;
+  items: SettingItem[];
+}
+
 export default function SettingsPage() {
   const { user } = useAuthContext();
   const { resolvedTheme, setTheme } = useTheme();
 
-  const sections = [
+  const sections: SettingSection[] = [
     {
       title: 'Personal',
       items: [

--- a/src/features/shifts/MyShiftsPage.tsx
+++ b/src/features/shifts/MyShiftsPage.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import { CalendarIcon, ClockIcon, FunnelIcon, DownloadSimpleIcon } from "@phosphor-icons/react";
+import { CalendarIcon, FunnelIcon, DownloadSimpleIcon } from "@phosphor-icons/react";
 
 /**
  * --- MY SHIFTS PAGE ---

--- a/src/shared/api/supabaseClient.ts
+++ b/src/shared/api/supabaseClient.ts
@@ -20,7 +20,7 @@ if (!supabasePublisherKey) {
 // Ensure the URL is valid.
 try {
     new URL(supabaseUrl);
-} catch (e) {
+} catch {
     throw new Error(`INVALID: VITE_SUPABASE_URL "${supabaseUrl}" is not a valid URL.`);
 }
 

--- a/src/shared/components/PageLoader.tsx
+++ b/src/shared/components/PageLoader.tsx
@@ -1,0 +1,15 @@
+/**
+ * --- PAGE LOADER ---
+ * Full-viewport loading state shown while a lazy-loaded route chunk is
+ * being fetched. Mirrors the spinner used in AppShell for visual consistency.
+ */
+export function PageLoader() {
+  return (
+    <div className="min-h-dvh flex items-center justify-center bg-white dark:bg-gray-950 transition-colors duration-500">
+      <div className="flex flex-col items-center gap-4">
+        <div className="w-16 h-16 border-4 border-emerald-500 border-t-transparent rounded-full animate-spin shadow-lg shadow-emerald-500/20"></div>
+        <p className="text-emerald-600 dark:text-emerald-400 font-bold text-sm animate-pulse">Loading...</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Fix all TypeScript/ESLint errors that broke the production build:
- AppShell: remove unused isShiftsLoading binding
- SettingsPage: type sections so optional `action` is valid
- MyShiftsPage: remove unused ClockIcon import
- supabaseClient: use optional catch binding for unused error

Improve initial load with React.lazy route code-splitting. Each page
now ships as its own chunk and loads on demand, dropping the initial
JS payload. Adds a shared PageLoader for the Suspense fallback.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MCvGiJaoBJEBTG93k2pi5A