### PR TITLE
feat(admin): email invitations, role/org management & self-delete guard

### DIFF
--- a/src/features/admin/AdminContext.tsx
+++ b/src/features/admin/AdminContext.tsx
@@ -135,10 +135,11 @@ export function AdminProvider({ children }: { children: ReactNode }) {
 
     const deleteEmployee = useCallback(
         async (id: string) => {
+            if (id === user?.id) throw new Error('You cannot delete your own account.');
             await adminService.deleteEmployee(id);
             await refreshData();
         },
-        [refreshData],
+        [user?.id, refreshData],
     );
 
     const value: AdminContextType = {

--- a/src/features/admin/AdminContext.tsx
+++ b/src/features/admin/AdminContext.tsx
@@ -6,7 +6,7 @@ import {
     useCallback,
     type ReactNode,
 } from 'react';
-import { adminService, type EmployeeUpdate } from './adminService';
+import { adminService, type EmployeeUpdate, type EmployeeInvite } from './adminService';
 import { useAuthContext } from '@/features/auth/AuthContext';
 import type { Organization, Role } from '@/shared/types';
 
@@ -36,6 +36,7 @@ interface AdminContextType {
     deleteLocation: (id: string) => Promise<void>;
 
     // Employees
+    inviteEmployee: (payload: EmployeeInvite) => Promise<void>;
     updateEmployee: (id: string, values: EmployeeUpdate) => Promise<void>;
     deleteEmployee: (id: string) => Promise<void>;
 }
@@ -125,6 +126,14 @@ export function AdminProvider({ children }: { children: ReactNode }) {
     );
 
     // Employees -----------------------------------------------------
+    const inviteEmployee = useCallback(
+        async (payload: EmployeeInvite) => {
+            await adminService.inviteEmployee(payload);
+            await refreshData();
+        },
+        [refreshData],
+    );
+
     const updateEmployee = useCallback(
         async (id: string, values: EmployeeUpdate) => {
             await adminService.updateEmployee(id, values);
@@ -155,6 +164,7 @@ export function AdminProvider({ children }: { children: ReactNode }) {
         createLocation,
         updateLocation,
         deleteLocation,
+        inviteEmployee,
         updateEmployee,
         deleteEmployee,
     };

--- a/src/features/admin/AdminPage.tsx
+++ b/src/features/admin/AdminPage.tsx
@@ -5,9 +5,11 @@ import {
     MapPinIcon,
     UsersIcon,
     PlusIcon,
+    PaperPlaneTiltIcon,
     PencilSimpleIcon,
     TrashIcon,
     MagnifyingGlassIcon,
+    type Icon,
 } from '@phosphor-icons/react';
 import type { Organization, Profile } from '@/shared/types';
 import { getRoleBadgeColor } from '@/shared/utils/roleColors';
@@ -19,6 +21,7 @@ import { ConfirmDialog } from './components/Modal';
 import { OrganizationForm } from './components/OrganizationForm';
 import { LocationForm, type LocationEditTarget } from './components/LocationForm';
 import { EmployeeForm } from './components/EmployeeForm';
+import { InviteEmployeeForm } from './components/InviteEmployeeForm';
 
 type TabType = 'employees' | 'locations' | 'organizations';
 
@@ -33,8 +36,15 @@ type ModalState =
     | { kind: 'org-form'; org?: Organization }
     | { kind: 'loc-form'; loc?: LocationEditTarget }
     | { kind: 'emp-form'; emp: Profile }
+    | { kind: 'invite-emp' }
     | { kind: 'delete'; entity: TabType; id: string; label: string }
     | null;
+
+const ADD_LABEL: Record<TabType, string> = {
+    organizations: 'Add Organization',
+    locations: 'Add Location',
+    employees: 'Invite Employee',
+};
 
 /**
  * --- ADMIN PAGE ---
@@ -107,12 +117,10 @@ function AdminPanel() {
         return all.filter((o) => `${o.name} ${o.slug ?? ''}`.toLowerCase().includes(query));
     }, [adminData, query]);
 
-    // Employees can't be created from the client (accounts come from sign-up).
-    const canAdd = safeTab !== 'employees';
-
     const handleAdd = () => {
         if (safeTab === 'organizations') setModal({ kind: 'org-form' });
         else if (safeTab === 'locations') setModal({ kind: 'loc-form' });
+        else setModal({ kind: 'invite-emp' });
     };
 
     const confirmDelete = async () => {
@@ -122,25 +130,48 @@ function AdminPanel() {
         else await deleteEmployee(modal.id);
     };
 
+    const orgCount = adminData?.length ?? 0;
+    const locCount = adminData?.reduce((n, o) => n + o.locations.length, 0) ?? 0;
+    const empCount = adminData?.reduce((n, o) => n + o.profiles.length, 0) ?? 0;
+
     return (
         <div className="space-y-6 px-1 max-w-7xl mx-auto w-full">
             {/* --- HEADER --- */}
-            <header className="flex flex-col sm:flex-row sm:items-end justify-between gap-4">
-                <div className="space-y-0.5">
-                    <p className="text-emerald-500 font-bold text-[10px] uppercase tracking-widest">System Infrastructure</p>
-                    <h1 className="text-gray-900 dark:text-white font-black text-2xl tracking-tight">Admin Panel</h1>
-                </div>
+            <header className="relative overflow-hidden rounded-3xl border border-emerald-100 dark:border-emerald-900/30 bg-gradient-to-br from-emerald-50 via-white to-white dark:from-emerald-950/40 dark:via-gray-900/40 dark:to-gray-900/40 p-5 sm:p-6">
+                <div className="absolute -right-8 -top-10 w-40 h-40 rounded-full bg-emerald-400/10 blur-2xl" />
+                <div className="relative flex flex-col sm:flex-row sm:items-end justify-between gap-4">
+                    <div className="space-y-1">
+                        <p className="text-emerald-500 font-bold text-[10px] uppercase tracking-widest">
+                            System Infrastructure
+                        </p>
+                        <h1 className="text-gray-900 dark:text-white font-black text-2xl sm:text-3xl tracking-tight">
+                            Admin Panel
+                        </h1>
+                        <p className="text-xs font-medium text-gray-400">
+                            {isSuperAdmin ? 'Full system access' : 'Managing your organization'}
+                        </p>
+                    </div>
 
-                {canAdd && (
                     <button
                         onClick={handleAdd}
-                        className="flex items-center justify-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-white px-4 py-2.5 rounded-xl font-bold text-xs transition-all active:scale-95 shadow-lg shadow-emerald-500/20"
+                        className="flex items-center justify-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-white px-4 py-2.5 rounded-xl font-bold text-xs transition-all active:scale-95 shadow-lg shadow-emerald-500/25"
                     >
-                        <PlusIcon weight="bold" className="w-4 h-4" />
-                        <span>Add New {safeTab === 'organizations' ? 'Organization' : 'Location'}</span>
+                        {safeTab === 'employees' ? (
+                            <PaperPlaneTiltIcon weight="bold" className="w-4 h-4" />
+                        ) : (
+                            <PlusIcon weight="bold" className="w-4 h-4" />
+                        )}
+                        <span>{ADD_LABEL[safeTab]}</span>
                     </button>
-                )}
+                </div>
             </header>
+
+            {/* --- STATS --- */}
+            <div className={`grid gap-3 ${isSuperAdmin ? 'grid-cols-3' : 'grid-cols-2'}`}>
+                <StatCard icon={UsersIcon} label="Employees" value={empCount} accent="emerald" />
+                <StatCard icon={MapPinIcon} label="Locations" value={locCount} accent="blue" />
+                {isSuperAdmin && <StatCard icon={BuildingsIcon} label="Organizations" value={orgCount} accent="violet" />}
+            </div>
 
             {/* --- TABS & SEARCH --- */}
             <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
@@ -244,6 +275,7 @@ function AdminPanel() {
                 {modal?.kind === 'org-form' && <OrganizationForm org={modal.org} onClose={() => setModal(null)} />}
                 {modal?.kind === 'loc-form' && <LocationForm location={modal.loc} onClose={() => setModal(null)} />}
                 {modal?.kind === 'emp-form' && <EmployeeForm employee={modal.emp} onClose={() => setModal(null)} />}
+                {modal?.kind === 'invite-emp' && <InviteEmployeeForm onClose={() => setModal(null)} />}
                 {modal?.kind === 'delete' && (
                     <ConfirmDialog
                         title="Confirm Deletion"
@@ -260,6 +292,26 @@ function AdminPanel() {
 // ==========================================
 // STATE HELPERS
 // ==========================================
+
+const STAT_ACCENTS: Record<string, string> = {
+    emerald: 'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 dark:text-emerald-400',
+    blue: 'bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400',
+    violet: 'bg-violet-50 dark:bg-violet-900/20 text-violet-600 dark:text-violet-400',
+};
+
+function StatCard({ icon: StatIcon, label, value, accent }: { icon: Icon; label: string; value: number; accent: string }) {
+    return (
+        <div className="flex items-center gap-3 p-3 sm:p-4 bg-white dark:bg-gray-800/30 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm">
+            <div className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 ${STAT_ACCENTS[accent]}`}>
+                <StatIcon className="w-5 h-5" weight="bold" />
+            </div>
+            <div className="min-w-0">
+                <p className="text-xl sm:text-2xl font-black text-gray-900 dark:text-white leading-none">{value}</p>
+                <p className="text-[9px] sm:text-[10px] font-bold text-gray-400 uppercase tracking-widest mt-1">{label}</p>
+            </div>
+        </div>
+    );
+}
 
 function LoadingState({ label }: { label: string }) {
     return (

--- a/src/features/admin/AdminPage.tsx
+++ b/src/features/admin/AdminPage.tsx
@@ -13,6 +13,7 @@ import type { Organization, Profile } from '@/shared/types';
 import { getRoleBadgeColor } from '@/shared/utils/roleColors';
 import { getFullInitials } from '@/shared/utils/getInitials';
 
+import { useAuthContext } from '@/features/auth/AuthContext';
 import { AdminProvider, useAdminContext } from './AdminContext';
 import { ConfirmDialog } from './components/Modal';
 import { OrganizationForm } from './components/OrganizationForm';
@@ -57,6 +58,7 @@ function AdminPanel() {
         deleteLocation,
         deleteEmployee,
     } = useAdminContext();
+    const { user } = useAuthContext();
 
     const [activeTab, setActiveTab] = useState<TabType>('employees');
     const [searchQuery, setSearchQuery] = useState('');
@@ -220,6 +222,7 @@ function AdminPanel() {
                                 <EmployeesList
                                     items={employees}
                                     isLoading={isLoading}
+                                    currentUserId={user?.id}
                                     onEdit={(emp) => setModal({ kind: 'emp-form', emp })}
                                     onDelete={(emp) =>
                                         setModal({
@@ -416,11 +419,13 @@ function LocationsList({
 function EmployeesList({
     items,
     isLoading,
+    currentUserId,
     onEdit,
     onDelete,
 }: {
     items: Profile[];
     isLoading: boolean;
+    currentUserId?: string;
     onEdit: (emp: Profile) => void;
     onDelete: (emp: Profile) => void;
 }) {
@@ -429,42 +434,54 @@ function EmployeesList({
 
     return (
         <div className="grid gap-2">
-            {items.map((employee) => (
-                <div
-                    key={employee.id}
-                    className="flex items-center gap-2 sm:gap-3 p-1.5 sm:p-2 bg-white dark:bg-gray-800/30 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm"
-                >
-                    <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-full bg-emerald-100 dark:bg-emerald-900/40 border-2 border-white dark:border-white/10 flex items-center justify-center text-emerald-700 dark:text-emerald-400 text-[10px] font-black shrink-0">
-                        {getFullInitials(employee.first_name, employee.last_name)}
-                    </div>
-                    <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-1.5">
-                            <h3 className="font-bold text-xs sm:text-sm dark:text-white truncate leading-tight">
-                                {employee.first_name} {employee.last_name}
-                            </h3>
-                            {employee.role.is_admin && <AdminBadgeWithTooltip />}
+            {items.map((employee) => {
+                const isSelf = employee.id === currentUserId;
+                return (
+                    <div
+                        key={employee.id}
+                        className="flex items-center gap-2 sm:gap-3 p-1.5 sm:p-2 bg-white dark:bg-gray-800/30 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm"
+                    >
+                        <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-full bg-emerald-100 dark:bg-emerald-900/40 border-2 border-white dark:border-white/10 flex items-center justify-center text-emerald-700 dark:text-emerald-400 text-[10px] font-black shrink-0">
+                            {getFullInitials(employee.first_name, employee.last_name)}
                         </div>
-                        <p className="text-[9px] sm:text-[10px] text-gray-400 font-bold uppercase tracking-tight truncate">
-                            {employee.email}
-                        </p>
+                        <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-1.5">
+                                <h3 className="font-bold text-xs sm:text-sm dark:text-white truncate leading-tight">
+                                    {employee.first_name} {employee.last_name}
+                                </h3>
+                                {employee.role.is_admin && <AdminBadgeWithTooltip />}
+                                {isSelf && (
+                                    <span className="shrink-0 px-1.5 py-0.5 text-[7px] sm:text-[8px] font-black rounded uppercase tracking-widest bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400">
+                                        You
+                                    </span>
+                                )}
+                            </div>
+                            <p className="text-[9px] sm:text-[10px] text-gray-400 font-bold uppercase tracking-tight truncate">
+                                {employee.email}
+                            </p>
+                        </div>
+                        <div className="flex items-center gap-2 sm:gap-4 shrink-0">
+                            <span
+                                className={`px-1.5 py-0.5 sm:px-2 sm:py-1 text-[7px] sm:text-[8px] font-black rounded-md uppercase tracking-widest ${getRoleBadgeColor(
+                                    employee.role.name,
+                                )}`}
+                            >
+                                {employee.role.name}
+                            </span>
+                            {/* You can edit your own profile, but never delete your own account. */}
+                            <ActionButtons
+                                onEdit={() => onEdit(employee)}
+                                onDelete={isSelf ? undefined : () => onDelete(employee)}
+                            />
+                        </div>
                     </div>
-                    <div className="flex items-center gap-2 sm:gap-4 shrink-0">
-                        <span
-                            className={`px-1.5 py-0.5 sm:px-2 sm:py-1 text-[7px] sm:text-[8px] font-black rounded-md uppercase tracking-widest ${getRoleBadgeColor(
-                                employee.role.name,
-                            )}`}
-                        >
-                            {employee.role.name}
-                        </span>
-                        <ActionButtons onEdit={() => onEdit(employee)} onDelete={() => onDelete(employee)} />
-                    </div>
-                </div>
-            ))}
+                );
+            })}
         </div>
     );
 }
 
-function ActionButtons({ onEdit, onDelete }: { onEdit: () => void; onDelete: () => void }) {
+function ActionButtons({ onEdit, onDelete }: { onEdit: () => void; onDelete?: () => void }) {
     return (
         <div className="flex items-center gap-0.5">
             <button
@@ -474,13 +491,15 @@ function ActionButtons({ onEdit, onDelete }: { onEdit: () => void; onDelete: () 
             >
                 <PencilSimpleIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" weight="bold" />
             </button>
-            <button
-                onClick={onDelete}
-                className="p-1.5 sm:p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-500/10 rounded-lg transition-colors"
-                aria-label="Delete"
-            >
-                <TrashIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" weight="bold" />
-            </button>
+            {onDelete && (
+                <button
+                    onClick={onDelete}
+                    className="p-1.5 sm:p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-500/10 rounded-lg transition-colors"
+                    aria-label="Delete"
+                >
+                    <TrashIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" weight="bold" />
+                </button>
+            )}
         </div>
     );
 }

--- a/src/features/admin/adminService.tsx
+++ b/src/features/admin/adminService.tsx
@@ -28,6 +28,15 @@ export interface EmployeeUpdate {
     first_name: string | null;
     last_name: string | null;
     role: string;
+    organization_id?: string;
+}
+
+export interface EmployeeInvite {
+    email: string;
+    organization_id: string;
+    role: string;
+    first_name?: string | null;
+    last_name?: string | null;
 }
 
 export const adminService = {
@@ -127,4 +136,31 @@ export const adminService = {
         const { error } = await supabase.from('profiles').delete().eq('id', id);
         if (error) throw error;
     },
+
+    /**
+     * Invites a new user by email via the `invite-employee` Edge Function.
+     * The function enforces role/organization scoping based on the caller.
+     */
+    async inviteEmployee(payload: EmployeeInvite): Promise<void> {
+        const { error } = await supabase.functions.invoke('invite-employee', { body: payload });
+        if (error) throw await toFunctionError(error);
+    },
 };
+
+/**
+ * Edge Functions return their error body with a non-2xx status, which supabase-js
+ * surfaces as a FunctionsHttpError whose `context` is the raw Response. Pull the
+ * server's `error` message out of it so the UI can show something meaningful.
+ */
+async function toFunctionError(error: unknown): Promise<Error> {
+    const context = (error as { context?: Response }).context;
+    if (context && typeof context.json === 'function') {
+        try {
+            const body = await context.json();
+            if (body?.error) return new Error(body.error);
+        } catch {
+            // fall through to the generic message
+        }
+    }
+    return error instanceof Error ? error : new Error('Failed to send invitation.');
+}

--- a/src/features/admin/components/EmployeeForm.tsx
+++ b/src/features/admin/components/EmployeeForm.tsx
@@ -12,13 +12,17 @@ import type { Profile } from '@/shared/types';
  * form manages the profile + role of users who already exist.
  */
 export function EmployeeForm({ employee, onClose }: { employee: Profile; onClose: () => void }) {
-    const { roles, isSuperAdmin, updateEmployee } = useAdminContext();
+    const { adminData, roles, isSuperAdmin, updateEmployee } = useAdminContext();
 
     const [firstName, setFirstName] = useState(employee.first_name ?? '');
     const [lastName, setLastName] = useState(employee.last_name ?? '');
     const [role, setRole] = useState(employee.role.name);
+    const [organizationId, setOrganizationId] = useState(employee.organization_id);
     const [isBusy, setIsBusy] = useState(false);
     const [error, setError] = useState<string | null>(null);
+
+    // Only Superadmins can move a user to another organization.
+    const showOrgSelect = isSuperAdmin && (adminData?.length ?? 0) > 1;
 
     // Regular admins can't promote anyone to Superadmin — but always keep the
     // employee's current role available so the <select> stays valid.
@@ -35,6 +39,7 @@ export function EmployeeForm({ employee, onClose }: { employee: Profile; onClose
                 first_name: firstName.trim() || null,
                 last_name: lastName.trim() || null,
                 role,
+                ...(isSuperAdmin ? { organization_id: organizationId } : {}),
             });
             onClose();
         } catch (err) {
@@ -65,6 +70,18 @@ export function EmployeeForm({ employee, onClose }: { employee: Profile; onClose
                         ))}
                     </SelectInput>
                 </Field>
+
+                {showOrgSelect && (
+                    <Field label="Organization">
+                        <SelectInput value={organizationId} onChange={(e) => setOrganizationId(e.target.value)}>
+                            {adminData?.map((org) => (
+                                <option key={org.id} value={org.id}>
+                                    {org.name}
+                                </option>
+                            ))}
+                        </SelectInput>
+                    </Field>
+                )}
 
                 <FormError message={error} />
                 <FormActions onCancel={onClose} isBusy={isBusy} submitLabel="Save" />

--- a/src/features/admin/components/InviteEmployeeForm.tsx
+++ b/src/features/admin/components/InviteEmployeeForm.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { Modal } from './Modal';
+import { Field, TextInput, SelectInput, FormError, FormActions } from './FormControls';
+import { useAdminContext } from '../AdminContext';
+import { useAuthContext } from '@/features/auth/AuthContext';
+
+/**
+ * Invite a brand-new user by email.
+ *
+ * Superadmins choose the organization + any role. Org admins always invite into
+ * their own organization and cannot grant the Superadmin role (enforced again
+ * server-side by the invite-employee Edge Function).
+ */
+export function InviteEmployeeForm({ onClose }: { onClose: () => void }) {
+    const { adminData, roles, isSuperAdmin, inviteEmployee } = useAdminContext();
+    const { user } = useAuthContext();
+
+    const ownOrgId = user?.organization_id ?? '';
+    const assignableRoles = roles.filter((r) => isSuperAdmin || r.name !== 'Superadmin');
+
+    const [email, setEmail] = useState('');
+    const [firstName, setFirstName] = useState('');
+    const [lastName, setLastName] = useState('');
+    const [role, setRole] = useState('Employee');
+    const [organizationId, setOrganizationId] = useState(adminData?.[0]?.id ?? ownOrgId);
+    const [isBusy, setIsBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const showOrgSelect = isSuperAdmin && (adminData?.length ?? 0) > 0;
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        const trimmedEmail = email.trim().toLowerCase();
+        if (!trimmedEmail.includes('@')) return setError('A valid email is required.');
+
+        setIsBusy(true);
+        setError(null);
+        try {
+            await inviteEmployee({
+                email: trimmedEmail,
+                organization_id: isSuperAdmin ? organizationId : ownOrgId,
+                role,
+                first_name: firstName.trim() || null,
+                last_name: lastName.trim() || null,
+            });
+            onClose();
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Could not send the invitation.');
+            setIsBusy(false);
+        }
+    };
+
+    return (
+        <Modal title="Invite Employee" subtitle="Email invitation" onClose={onClose}>
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <Field label="Email">
+                    <TextInput
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="new.member@company.com"
+                        autoFocus
+                    />
+                </Field>
+
+                <div className="grid grid-cols-2 gap-3">
+                    <Field label="First name">
+                        <TextInput value={firstName} onChange={(e) => setFirstName(e.target.value)} placeholder="Jane" />
+                    </Field>
+                    <Field label="Last name">
+                        <TextInput value={lastName} onChange={(e) => setLastName(e.target.value)} placeholder="Doe" />
+                    </Field>
+                </div>
+
+                {showOrgSelect && (
+                    <Field label="Organization">
+                        <SelectInput value={organizationId} onChange={(e) => setOrganizationId(e.target.value)}>
+                            {adminData?.map((org) => (
+                                <option key={org.id} value={org.id}>
+                                    {org.name}
+                                </option>
+                            ))}
+                        </SelectInput>
+                    </Field>
+                )}
+
+                <Field label="Role">
+                    <SelectInput value={role} onChange={(e) => setRole(e.target.value)}>
+                        {assignableRoles.map((r) => (
+                            <option key={r.name} value={r.name}>
+                                {r.name}
+                                {r.description ? ` — ${r.description}` : ''}
+                            </option>
+                        ))}
+                    </SelectInput>
+                </Field>
+
+                <FormError message={error} />
+                <FormActions onCancel={onClose} isBusy={isBusy} submitLabel="Send invite" />
+            </form>
+        </Modal>
+    );
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -368,6 +368,12 @@ deno_version = 2
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 
+# Invitation function — requires the caller to be an authenticated admin; the
+# function itself enforces role/organization scoping.
+[functions.invite-employee]
+enabled = true
+verify_jwt = true
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/invite-employee/README.md
+++ b/supabase/functions/invite-employee/README.md
@@ -1,0 +1,34 @@
+# invite-employee
+
+Edge Function that invites a new user by email and provisions them into an
+organization with a role. Runs with the `service_role` key (server-side only).
+
+Authorization is derived from the **caller's** JWT:
+
+| Caller        | Organization              | Role                          |
+| ------------- | ------------------------- | ----------------------------- |
+| Superadmin    | any (chosen in the UI)    | any (incl. Admin)             |
+| Org admin     | forced to their own org   | any except `Superadmin`       |
+| anyone else   | — (rejected)              | —                             |
+
+The chosen `organization_id` + `role` are passed as invite metadata and applied
+by the `handle_new_user` trigger (see migration `*_invite_aware_provisioning.sql`).
+
+## Deploy
+
+```bash
+# 1. Apply the migrations (trigger + RLS for org admins)
+supabase db push
+
+# 2. Deploy the function
+supabase functions deploy invite-employee
+```
+
+## Requirements
+
+- **SMTP** must be configured in the Supabase dashboard (Auth → Email) for invite
+  emails to actually be delivered. Without it, invites are created but no email
+  is sent (locally they are captured by Inbucket).
+- `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY` are injected
+  automatically by the platform. Optionally set `SITE_URL` (the invite redirect
+  target) via `supabase secrets set SITE_URL=https://your-app`.

--- a/supabase/functions/invite-employee/index.ts
+++ b/supabase/functions/invite-employee/index.ts
@@ -1,0 +1,123 @@
+// =============================================================================
+// EDGE FUNCTION: invite-employee
+// -----------------------------------------------------------------------------
+// Invites a new user by email and provisions them into an organization with a
+// role. Runs server-side with the service_role key (never exposed to clients).
+//
+// Authorization is derived from the CALLER's JWT, not the request body:
+//   * Superadmin      -> may invite into ANY organization, with ANY role.
+//   * Org admin       -> forced into their OWN organization; cannot assign
+//     (is_admin role)    the Superadmin role.
+//   * Everyone else   -> rejected.
+//
+// The chosen organization + role travel as user metadata and are applied
+// atomically by the handle_new_user trigger (see the companion migration).
+// =============================================================================
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+function json(body: unknown, status = 200) {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+}
+
+Deno.serve(async (req) => {
+    if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+    if (req.method !== 'POST') return json({ error: 'Method not allowed.' }, 405);
+
+    try {
+        const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+        const ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY')!;
+        const SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+        const authHeader = req.headers.get('Authorization');
+        if (!authHeader) return json({ error: 'Missing Authorization header.' }, 401);
+
+        // 1. Identify the caller from their JWT.
+        const callerClient = createClient(SUPABASE_URL, ANON_KEY, {
+            global: { headers: { Authorization: authHeader } },
+        });
+        const {
+            data: { user: caller },
+            error: callerError,
+        } = await callerClient.auth.getUser();
+        if (callerError || !caller) return json({ error: 'Invalid or expired session.' }, 401);
+
+        // 2. Admin (service_role) client — bypasses RLS for trusted operations.
+        const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+            auth: { autoRefreshToken: false, persistSession: false },
+        });
+
+        // 3. Load the caller's profile + whether their role is an admin role.
+        const { data: callerProfile, error: profileError } = await admin
+            .from('profiles')
+            .select('organization_id, role')
+            .eq('id', caller.id)
+            .single();
+        if (profileError || !callerProfile) return json({ error: 'Caller profile not found.' }, 403);
+
+        const { data: callerRole } = await admin
+            .from('roles')
+            .select('is_admin')
+            .eq('name', callerProfile.role)
+            .single();
+
+        const isSuperadmin = callerProfile.role === 'Superadmin';
+        const isAdmin = isSuperadmin || Boolean(callerRole?.is_admin);
+        if (!isAdmin) return json({ error: 'You are not allowed to invite users.' }, 403);
+
+        // 4. Parse + validate the request body.
+        const body = await req.json().catch(() => ({}));
+        const email = String(body.email ?? '').trim().toLowerCase();
+        const firstName = body.first_name ? String(body.first_name).trim() : null;
+        const lastName = body.last_name ? String(body.last_name).trim() : null;
+        let organizationId = body.organization_id ? String(body.organization_id) : '';
+        const role = body.role ? String(body.role) : 'Employee';
+
+        if (!email || !email.includes('@')) return json({ error: 'A valid email is required.' }, 400);
+
+        // 5. Apply role-based scoping (server is the source of truth).
+        if (!isSuperadmin) {
+            organizationId = callerProfile.organization_id; // org admins can only invite into their own org
+            if (role === 'Superadmin') {
+                return json({ error: 'Only a Superadmin can assign the Superadmin role.' }, 403);
+            }
+        }
+        if (!organizationId) return json({ error: 'An organization is required.' }, 400);
+
+        // 6. Validate role + organization exist.
+        const [{ data: roleRow }, { data: orgRow }] = await Promise.all([
+            admin.from('roles').select('name').eq('name', role).single(),
+            admin.from('organizations').select('id').eq('id', organizationId).single(),
+        ]);
+        if (!roleRow) return json({ error: `Unknown role "${role}".` }, 400);
+        if (!orgRow) return json({ error: 'Unknown organization.' }, 400);
+
+        // 7. Send the invitation. The trigger reads this metadata to provision
+        //    the profile into the right org + role.
+        const siteUrl = Deno.env.get('SITE_URL');
+        const { data: invited, error: inviteError } = await admin.auth.admin.inviteUserByEmail(email, {
+            data: {
+                organization_id: organizationId,
+                role,
+                first_name: firstName,
+                last_name: lastName,
+            },
+            ...(siteUrl ? { redirectTo: siteUrl } : {}),
+        });
+
+        if (inviteError) return json({ error: inviteError.message }, 400);
+
+        return json({ success: true, user_id: invited?.user?.id ?? null }, 200);
+    } catch (err) {
+        return json({ error: err instanceof Error ? err.message : 'Unexpected error.' }, 500);
+    }
+});

--- a/supabase/migrations/20260617010000_invite_aware_provisioning.sql
+++ b/supabase/migrations/20260617010000_invite_aware_provisioning.sql
@@ -1,0 +1,57 @@
+-- =============================================================================
+-- INVITE-AWARE USER PROVISIONING
+-- -----------------------------------------------------------------------------
+-- New users are created via the `invite-employee` Edge Function, which sets the
+-- target organization + role (and optional names) as user metadata. This makes
+-- the handle_new_user trigger honor that metadata so the profile lands in the
+-- right organization with the right role in a single, atomic step.
+--
+-- Falls back to the default organization + 'Employee' for any other signup path
+-- (keeping previous behaviour). Metadata is set server-side by the Edge Function
+-- (service_role), never by the client, so it is trusted.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_org_id uuid;
+  v_role text;
+  v_username text;
+BEGIN
+  -- Organization: prefer invite metadata, else the seeded default organization.
+  v_org_id := NULLIF(new.raw_user_meta_data->>'organization_id', '')::uuid;
+  IF v_org_id IS NULL THEN
+    SELECT id INTO v_org_id FROM public.organizations WHERE slug = 'default-org';
+  END IF;
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'No organization for new user: provide organization_id metadata or seed a "default-org".';
+  END IF;
+
+  -- Role: prefer invite metadata, else Employee. (FK to roles enforces validity.)
+  v_role := COALESCE(NULLIF(new.raw_user_meta_data->>'role', ''), 'Employee');
+
+  -- Username fallback chain: metadata -> email prefix -> random.
+  v_username := COALESCE(
+    NULLIF(new.raw_user_meta_data->>'username', ''),
+    split_part(new.email, '@', 1),
+    'user_' || substr(md5(random()::text), 1, 8)
+  );
+
+  INSERT INTO public.profiles (id, username, role, email, organization_id, first_name, last_name)
+  VALUES (
+    new.id,
+    v_username,
+    v_role,
+    new.email,
+    v_org_id,
+    NULLIF(new.raw_user_meta_data->>'first_name', ''),
+    NULLIF(new.raw_user_meta_data->>'last_name', '')
+  );
+
+  RETURN new;
+END;
+$$;


### PR DESCRIPTION
## Summary

Builds out the Admin Panel into a full user/organization administration system.

### Invitations (new)
- **Edge Function `invite-employee`** — invites users by email server-side (`service_role`), scoped by the **caller's** role:
  - Superadmin → any organization + any role (incl. Admin)
  - Org admin → forced to their own org, cannot grant Superadmin
  - anyone else → rejected
- Migration makes `handle_new_user` honor `organization_id` + `role` from invite metadata, provisioning the profile atomically.
- `InviteEmployeeForm` + an Invite button on the Employees tab.

### Editing & permissions
- Superadmin can move a user to another organization; org admins edit role only.
- Org admins can grant the Admin role to others (not Superadmin).
- Org-scoped location + member management via RLS (`is_org_admin()` migration).

### Safety
- Can no longer delete your own account (UI hides it + context guard, covering Superadmin who has no DB-level guard).

### UI polish
- Gradient header, stat cards (Employees / Locations / Organizations), per-tab Add/Invite action.

### ⚠️ Requires deployment
- `supabase db push` (migrations) + `supabase functions deploy invite-employee`
- SMTP configured in Supabase for invite emails to be delivered.

✅ `tsc -b` clean · ✅ `vite build` green · ✅ ESLint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCvGiJaoBJEBTG93k2pi5A)_