### PR TITLE
feat(admin): ranked role hierarchy & tightened permissions

### DIFF
--- a/src/features/admin/AdminPage.tsx
+++ b/src/features/admin/AdminPage.tsx
@@ -11,12 +11,13 @@ import {
     MagnifyingGlassIcon,
     type Icon,
 } from '@phosphor-icons/react';
-import type { Organization, Profile } from '@/shared/types';
+import type { Organization, Profile, User } from '@/shared/types';
 import { getRoleBadgeColor } from '@/shared/utils/roleColors';
 import { getFullInitials } from '@/shared/utils/getInitials';
 
 import { useAuthContext } from '@/features/auth/AuthContext';
 import { AdminProvider, useAdminContext } from './AdminContext';
+import { canManageEmployees, canManageLocations, canManageMember, RANK } from './permissions';
 import { ConfirmDialog } from './components/Modal';
 import { OrganizationForm } from './components/OrganizationForm';
 import { LocationForm, type LocationEditTarget } from './components/LocationForm';
@@ -134,6 +135,12 @@ function AdminPanel() {
     const locCount = adminData?.reduce((n, o) => n + o.locations.length, 0) ?? 0;
     const empCount = adminData?.reduce((n, o) => n + o.profiles.length, 0) ?? 0;
 
+    // Capability flags drive what the current user can do (mirrors RLS).
+    const canManageEmp = user ? canManageEmployees(user) : false;
+    const canManageLoc = user ? canManageLocations(user) : false;
+    const canAdd =
+        safeTab === 'employees' ? canManageEmp : safeTab === 'locations' ? canManageLoc : isSuperAdmin;
+
     return (
         <div className="space-y-6 px-1 max-w-7xl mx-auto w-full">
             {/* --- HEADER --- */}
@@ -152,17 +159,19 @@ function AdminPanel() {
                         </p>
                     </div>
 
-                    <button
-                        onClick={handleAdd}
-                        className="flex items-center justify-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-white px-4 py-2.5 rounded-xl font-bold text-xs transition-all active:scale-95 shadow-lg shadow-emerald-500/25"
-                    >
-                        {safeTab === 'employees' ? (
-                            <PaperPlaneTiltIcon weight="bold" className="w-4 h-4" />
-                        ) : (
-                            <PlusIcon weight="bold" className="w-4 h-4" />
-                        )}
-                        <span>{ADD_LABEL[safeTab]}</span>
-                    </button>
+                    {canAdd && (
+                        <button
+                            onClick={handleAdd}
+                            className="flex items-center justify-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-white px-4 py-2.5 rounded-xl font-bold text-xs transition-all active:scale-95 shadow-lg shadow-emerald-500/25"
+                        >
+                            {safeTab === 'employees' ? (
+                                <PaperPlaneTiltIcon weight="bold" className="w-4 h-4" />
+                            ) : (
+                                <PlusIcon weight="bold" className="w-4 h-4" />
+                            )}
+                            <span>{ADD_LABEL[safeTab]}</span>
+                        </button>
+                    )}
                 </div>
             </header>
 
@@ -243,6 +252,7 @@ function AdminPanel() {
                                 <LocationsList
                                     items={locations}
                                     isLoading={isLoading}
+                                    canManage={canManageLoc}
                                     onEdit={(loc) => setModal({ kind: 'loc-form', loc })}
                                     onDelete={(loc) =>
                                         setModal({ kind: 'delete', entity: 'locations', id: loc.id, label: loc.name })
@@ -253,7 +263,7 @@ function AdminPanel() {
                                 <EmployeesList
                                     items={employees}
                                     isLoading={isLoading}
-                                    currentUserId={user?.id}
+                                    currentUser={user}
                                     onEdit={(emp) => setModal({ kind: 'emp-form', emp })}
                                     onDelete={(emp) =>
                                         setModal({
@@ -431,11 +441,13 @@ function OrganizationsList({
 function LocationsList({
     items,
     isLoading,
+    canManage,
     onEdit,
     onDelete,
 }: {
     items: LocationRow[];
     isLoading: boolean;
+    canManage: boolean;
     onEdit: (loc: LocationRow) => void;
     onDelete: (loc: LocationRow) => void;
 }) {
@@ -460,7 +472,7 @@ function LocationsList({
                         <span className="hidden sm:inline-block px-2 py-1 bg-gray-100 dark:bg-gray-800 text-gray-500 text-[8px] font-black rounded uppercase tracking-widest">
                             {loc.id.slice(0, 8)}
                         </span>
-                        <ActionButtons onEdit={() => onEdit(loc)} onDelete={() => onDelete(loc)} />
+                        {canManage && <ActionButtons onEdit={() => onEdit(loc)} onDelete={() => onDelete(loc)} />}
                     </div>
                 </div>
             ))}
@@ -471,13 +483,13 @@ function LocationsList({
 function EmployeesList({
     items,
     isLoading,
-    currentUserId,
+    currentUser,
     onEdit,
     onDelete,
 }: {
     items: Profile[];
     isLoading: boolean;
-    currentUserId?: string;
+    currentUser: User | null;
     onEdit: (emp: Profile) => void;
     onDelete: (emp: Profile) => void;
 }) {
@@ -487,7 +499,8 @@ function EmployeesList({
     return (
         <div className="grid gap-2">
             {items.map((employee) => {
-                const isSelf = employee.id === currentUserId;
+                const isSelf = employee.id === currentUser?.id;
+                const manageable = currentUser ? canManageMember(currentUser, employee) : false;
                 return (
                     <div
                         key={employee.id}
@@ -501,7 +514,7 @@ function EmployeesList({
                                 <h3 className="font-bold text-xs sm:text-sm dark:text-white truncate leading-tight">
                                     {employee.first_name} {employee.last_name}
                                 </h3>
-                                {employee.role.is_admin && <AdminBadgeWithTooltip />}
+                                {employee.role.rank >= RANK.ADMIN && <AdminBadgeWithTooltip />}
                                 {isSelf && (
                                     <span className="shrink-0 px-1.5 py-0.5 text-[7px] sm:text-[8px] font-black rounded uppercase tracking-widest bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400">
                                         You
@@ -520,11 +533,10 @@ function EmployeesList({
                             >
                                 {employee.role.name}
                             </span>
-                            {/* You can edit your own profile, but never delete your own account. */}
-                            <ActionButtons
-                                onEdit={() => onEdit(employee)}
-                                onDelete={isSelf ? undefined : () => onDelete(employee)}
-                            />
+                            {/* Only members ranked below you can be edited or removed (never yourself). */}
+                            {manageable && (
+                                <ActionButtons onEdit={() => onEdit(employee)} onDelete={() => onDelete(employee)} />
+                            )}
                         </div>
                     </div>
                 );

--- a/src/features/admin/adminService.tsx
+++ b/src/features/admin/adminService.tsx
@@ -22,7 +22,7 @@ import { z } from 'zod';
 
 // Shared select used to hydrate the full organization tree (locations + members).
 const ORG_TREE_SELECT =
-    '*, locations(id, name, organization_id), profiles(id, role(name, is_admin), email, username, first_name, last_name, organization_id)';
+    '*, locations(id, name, organization_id), profiles(id, role(name, is_admin, rank), email, username, first_name, last_name, organization_id)';
 
 export interface EmployeeUpdate {
     first_name: string | null;
@@ -62,8 +62,8 @@ export const adminService = {
     async getRoles(): Promise<Role[]> {
         const { data, error } = await supabase
             .from('roles')
-            .select('name, color, description, is_admin')
-            .order('is_admin', { ascending: false })
+            .select('name, color, description, is_admin, rank')
+            .order('rank', { ascending: false })
             .order('name', { ascending: true });
 
         if (error) throw error;

--- a/src/features/admin/components/EmployeeForm.tsx
+++ b/src/features/admin/components/EmployeeForm.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { Modal } from './Modal';
 import { Field, TextInput, SelectInput, FormError, FormActions } from './FormControls';
 import { useAdminContext } from '../AdminContext';
+import { useAuthContext } from '@/features/auth/AuthContext';
+import { assignableRoles as getAssignableRoles } from '../permissions';
 import type { Profile } from '@/shared/types';
 
 /**
@@ -13,6 +15,7 @@ import type { Profile } from '@/shared/types';
  */
 export function EmployeeForm({ employee, onClose }: { employee: Profile; onClose: () => void }) {
     const { adminData, roles, isSuperAdmin, updateEmployee } = useAdminContext();
+    const { user } = useAuthContext();
 
     const [firstName, setFirstName] = useState(employee.first_name ?? '');
     const [lastName, setLastName] = useState(employee.last_name ?? '');
@@ -24,11 +27,10 @@ export function EmployeeForm({ employee, onClose }: { employee: Profile; onClose
     // Only Superadmins can move a user to another organization.
     const showOrgSelect = isSuperAdmin && (adminData?.length ?? 0) > 1;
 
-    // Regular admins can't promote anyone to Superadmin — but always keep the
-    // employee's current role available so the <select> stays valid.
-    const assignableRoles = roles.filter(
-        (r) => isSuperAdmin || r.name !== 'Superadmin' || r.name === employee.role.name,
-    );
+    // Roles strictly below the current user's rank (e.g. an Admin can assign up
+    // to Manager). The edited member always ranks below us, so their current
+    // role is already part of this list.
+    const roleOptions = user ? getAssignableRoles(roles, user) : [];
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -62,7 +64,7 @@ export function EmployeeForm({ employee, onClose }: { employee: Profile; onClose
 
                 <Field label="Role">
                     <SelectInput value={role} onChange={(e) => setRole(e.target.value)}>
-                        {assignableRoles.map((r) => (
+                        {roleOptions.map((r) => (
                             <option key={r.name} value={r.name}>
                                 {r.name}
                                 {r.description ? ` — ${r.description}` : ''}

--- a/src/features/admin/components/InviteEmployeeForm.tsx
+++ b/src/features/admin/components/InviteEmployeeForm.tsx
@@ -3,6 +3,7 @@ import { Modal } from './Modal';
 import { Field, TextInput, SelectInput, FormError, FormActions } from './FormControls';
 import { useAdminContext } from '../AdminContext';
 import { useAuthContext } from '@/features/auth/AuthContext';
+import { assignableRoles as getAssignableRoles } from '../permissions';
 
 /**
  * Invite a brand-new user by email.
@@ -16,7 +17,8 @@ export function InviteEmployeeForm({ onClose }: { onClose: () => void }) {
     const { user } = useAuthContext();
 
     const ownOrgId = user?.organization_id ?? '';
-    const assignableRoles = roles.filter((r) => isSuperAdmin || r.name !== 'Superadmin');
+    // Roles strictly below the inviter's rank (Admin -> up to Manager, etc.).
+    const roleOptions = user ? getAssignableRoles(roles, user) : [];
 
     const [email, setEmail] = useState('');
     const [firstName, setFirstName] = useState('');
@@ -86,7 +88,7 @@ export function InviteEmployeeForm({ onClose }: { onClose: () => void }) {
 
                 <Field label="Role">
                     <SelectInput value={role} onChange={(e) => setRole(e.target.value)}>
-                        {assignableRoles.map((r) => (
+                        {roleOptions.map((r) => (
                             <option key={r.name} value={r.name}>
                                 {r.name}
                                 {r.description ? ` — ${r.description}` : ''}

--- a/src/features/admin/permissions.ts
+++ b/src/features/admin/permissions.ts
@@ -1,0 +1,43 @@
+import type { User, Profile, Role } from '@/shared/types';
+
+/**
+ * --- ADMIN PERMISSIONS ---
+ * Capability checks derived from the role hierarchy (rank). Mirrors the RLS
+ * policies in the database so the UI only offers what the server will allow.
+ *
+ *   Superadmin 100 > Head Admin 40 > Admin 30 > Manager 20 > Supervisor 10 > Employee 0
+ */
+
+export const RANK = {
+    MANAGER: 20, // can view the admin panel
+    ADMIN: 30, // can invite + manage members below them
+    OWNER: 40, // "Head Admin" — can also manage locations
+} as const;
+
+export function isSuperAdmin(user: Pick<User, 'role'>): boolean {
+    return user.role.name === 'Superadmin';
+}
+
+/** Admin level or above: may invite and manage lower-ranked members. */
+export function canManageEmployees(user: Pick<User, 'role'>): boolean {
+    return user.role.rank >= RANK.ADMIN;
+}
+
+/** Head Admin (owner) or above: may create/edit/delete locations. */
+export function canManageLocations(user: Pick<User, 'role'>): boolean {
+    return user.role.rank >= RANK.OWNER;
+}
+
+/** Roles this user may assign/invite: strictly below their own rank. */
+export function assignableRoles(roles: Role[], user: Pick<User, 'role'>): Role[] {
+    return roles.filter((r) => r.rank < user.role.rank);
+}
+
+/**
+ * Whether this user may edit/delete a specific member: they must out-rank the
+ * target and it cannot be themselves.
+ */
+export function canManageMember(user: User, target: Pick<Profile, 'id' | 'role'>): boolean {
+    if (target.id === user.id) return false;
+    return canManageEmployees(user) && target.role.rank < user.role.rank;
+}

--- a/src/features/auth/authService.ts
+++ b/src/features/auth/authService.ts
@@ -24,7 +24,7 @@ export const authService = {
   async getUserProfile(userId: string): Promise<User | null> {
     const { data, error } = await supabase
       .from('profiles')
-      .select('id, username, first_name, last_name, role(name, is_admin), email, organization_id')
+      .select('id, username, first_name, last_name, role(name, is_admin, rank), email, organization_id')
       .eq('id', userId)
       .single();
 
@@ -39,7 +39,8 @@ export const authService = {
       first_name: validated.first_name ?? null,
       role: {
         name: validated.role.name,
-        is_admin: validated.role.is_admin
+        is_admin: validated.role.is_admin,
+        rank: validated.role.rank
       },
       email: validated.email,
       last_name: validated.last_name ?? null,

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -19,6 +19,7 @@ export const ProfileSchema = z.object({
   role: z.object({
     name: z.string(),
     is_admin: z.boolean(),
+    rank: z.number().default(0), // Position in the role hierarchy (higher = more privileged)
   }),
   organization_id: z.string(), // The company this user belongs to
 });
@@ -72,7 +73,8 @@ export const OrganizationSchema = z.object({
     id: z.string(),
     role: z.object({
       name: z.string(),
-      is_admin: z.boolean()
+      is_admin: z.boolean(),
+      rank: z.number().default(0)
     }),
     email: z.email(),
     username: z.string(),
@@ -92,6 +94,7 @@ export const RoleSchema = z.object({
   color: z.string(),
   description: z.string().nullable(),
   is_admin: z.boolean(),
+  rank: z.number().default(0),
 });
 
 /**

--- a/src/shared/utils/roleColors.ts
+++ b/src/shared/utils/roleColors.ts
@@ -1,8 +1,10 @@
 const ROLE_COLORS: Record<string, string> = {
-    Manager: 'bg-purple-600 text-white',
-    Supervisor: 'bg-emerald-500 text-white',
-    Employee: 'bg-lime-400 text-white',
     Superadmin: 'bg-red-900 text-white',
+    'Head Admin': 'bg-amber-500 text-white',
+    Admin: 'bg-red-500 text-white',
+    Manager: 'bg-purple-600 text-white',
+    Supervisor: 'bg-blue-500 text-white',
+    Employee: 'bg-lime-400 text-white',
 };
 
 export function getRoleBadgeColor(role: string): string {

--- a/supabase/functions/invite-employee/index.ts
+++ b/supabase/functions/invite-employee/index.ts
@@ -56,7 +56,7 @@ Deno.serve(async (req) => {
             auth: { autoRefreshToken: false, persistSession: false },
         });
 
-        // 3. Load the caller's profile + whether their role is an admin role.
+        // 3. Load the caller's profile + their role rank.
         const { data: callerProfile, error: profileError } = await admin
             .from('profiles')
             .select('organization_id, role')
@@ -66,13 +66,14 @@ Deno.serve(async (req) => {
 
         const { data: callerRole } = await admin
             .from('roles')
-            .select('is_admin')
+            .select('rank')
             .eq('name', callerProfile.role)
             .single();
 
         const isSuperadmin = callerProfile.role === 'Superadmin';
-        const isAdmin = isSuperadmin || Boolean(callerRole?.is_admin);
-        if (!isAdmin) return json({ error: 'You are not allowed to invite users.' }, 403);
+        const callerRank = Number(callerRole?.rank ?? 0);
+        // Inviting requires Admin level or above (rank >= 30). Managers and below cannot.
+        if (callerRank < 30) return json({ error: 'You are not allowed to invite users.' }, 403);
 
         // 4. Parse + validate the request body.
         const body = await req.json().catch(() => ({}));
@@ -84,22 +85,23 @@ Deno.serve(async (req) => {
 
         if (!email || !email.includes('@')) return json({ error: 'A valid email is required.' }, 400);
 
-        // 5. Apply role-based scoping (server is the source of truth).
+        // 5. Apply scoping (server is the source of truth).
         if (!isSuperadmin) {
             organizationId = callerProfile.organization_id; // org admins can only invite into their own org
-            if (role === 'Superadmin') {
-                return json({ error: 'Only a Superadmin can assign the Superadmin role.' }, 403);
-            }
         }
         if (!organizationId) return json({ error: 'An organization is required.' }, 400);
 
-        // 6. Validate role + organization exist.
+        // 6. Validate the organization, and that the role exists and is ranked
+        //    strictly below the caller (you can't invite a peer or superior).
         const [{ data: roleRow }, { data: orgRow }] = await Promise.all([
-            admin.from('roles').select('name').eq('name', role).single(),
+            admin.from('roles').select('name, rank').eq('name', role).single(),
             admin.from('organizations').select('id').eq('id', organizationId).single(),
         ]);
         if (!roleRow) return json({ error: `Unknown role "${role}".` }, 400);
         if (!orgRow) return json({ error: 'Unknown organization.' }, 400);
+        if (Number(roleRow.rank) >= callerRank) {
+            return json({ error: 'You cannot invite someone at or above your own role level.' }, 403);
+        }
 
         // 7. Send the invitation. The trigger reads this metadata to provision
         //    the profile into the right org + role.

--- a/supabase/migrations/20260617020000_role_hierarchy.sql
+++ b/supabase/migrations/20260617020000_role_hierarchy.sql
@@ -1,0 +1,129 @@
+-- =============================================================================
+-- ROLE HIERARCHY (ranks) + permission tightening
+-- -----------------------------------------------------------------------------
+-- Replaces the single is_admin "can do everything" flag with a ranked hierarchy:
+--
+--   Superadmin (100) > Head Admin (40) > Admin (30) > Manager (20)
+--                    > Supervisor (10) > Employee (0)
+--
+-- Capabilities (within one organization):
+--   * View admin panel : rank >= Manager (20)        -> is_admin = true
+--   * Invite / manage   : rank >= Admin   (30)
+--   * Manage locations  : rank >= Head Admin (40)     -> "owner"
+--   * Assign/invite role: only to a role with rank STRICTLY below your own
+--       - Head Admin can grant up to Admin
+--       - Admin      can grant up to Manager
+--       - Manager    can grant nothing (view only)
+--   * Only Superadmin can grant Head Admin.
+--
+-- A user can never change their OWN role/organization, and an admin can only
+-- act on members ranked below themselves. Enforced by both RLS and a trigger.
+-- =============================================================================
+
+-- 1. Rank column ------------------------------------------------------------
+ALTER TABLE public.roles ADD COLUMN IF NOT EXISTS rank smallint NOT NULL DEFAULT 0;
+
+-- 2. Roles + ranks (adds the new "Head Admin" owner role) -------------------
+INSERT INTO public.roles (name, color, description, is_admin, rank) VALUES
+  ('Superadmin', '#9333ea', 'Full system access',   true,  100),
+  ('Head Admin', '#f59e0b', 'Organization owner',    true,  40),
+  ('Admin',      '#ef4444', 'Organization admin',    true,  30),
+  ('Manager',    '#eab308', 'View only',             true,  20),
+  ('Supervisor', '#3b82f6', 'Shift control',         false, 10),
+  ('Employee',   '#22c55e', 'Employee',              false, 0)
+ON CONFLICT (name) DO UPDATE
+  SET is_admin    = EXCLUDED.is_admin,
+      rank        = EXCLUDED.rank,
+      description = EXCLUDED.description;
+
+-- 3. Rank helper functions (SECURITY DEFINER, no RLS recursion) -------------
+CREATE OR REPLACE FUNCTION public.role_rank(p_role text)
+RETURNS smallint LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT COALESCE((SELECT rank FROM public.roles WHERE name = p_role), 0)::smallint;
+$$;
+
+CREATE OR REPLACE FUNCTION public.my_role_rank()
+RETURNS smallint LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT COALESCE(
+    (SELECT r.rank
+       FROM public.profiles p
+       JOIN public.roles r ON r.name = p.role
+      WHERE p.id = auth.uid()),
+    0)::smallint;
+$$;
+
+GRANT ALL ON FUNCTION public.role_rank(text)  TO anon, authenticated, service_role;
+GRANT ALL ON FUNCTION public.my_role_rank()   TO anon, authenticated, service_role;
+
+-- 4. Remove the old over-permissive policies (they let Manager write) -------
+DROP POLICY IF EXISTS "Org admins manage locations" ON public.locations;
+DROP POLICY IF EXISTS "Org admins update members"   ON public.profiles;
+DROP POLICY IF EXISTS "Org admins delete members"   ON public.profiles;
+DROP FUNCTION IF EXISTS public.is_org_admin();
+
+-- 5. Rank-based policies -----------------------------------------------------
+
+-- Locations: only owners (Head Admin+) manage their own org's locations.
+CREATE POLICY "Owners manage locations"
+ON public.locations FOR ALL TO authenticated
+USING (public.my_role_rank() >= 40 AND organization_id = public.get_my_org_id())
+WITH CHECK (public.my_role_rank() >= 40 AND organization_id = public.get_my_org_id());
+
+-- Profiles UPDATE: Admin+ may update members ranked below them, and may only
+-- set a role ranked below them (the new-row role cannot reach their own level).
+CREATE POLICY "Admins update lower members"
+ON public.profiles FOR UPDATE TO authenticated
+USING (
+  public.my_role_rank() >= 30
+  AND organization_id = public.get_my_org_id()
+  AND public.role_rank(role) < public.my_role_rank()
+)
+WITH CHECK (
+  organization_id = public.get_my_org_id()
+  AND public.role_rank(role) < public.my_role_rank()
+);
+
+-- Profiles DELETE: Admin+ may remove members ranked below them (never self).
+CREATE POLICY "Admins delete lower members"
+ON public.profiles FOR DELETE TO authenticated
+USING (
+  public.my_role_rank() >= 30
+  AND organization_id = public.get_my_org_id()
+  AND public.role_rank(role) < public.my_role_rank()
+  AND id <> auth.uid()
+);
+
+-- 6. Defense-in-depth: a BEFORE UPDATE trigger that forbids changing the role
+--    or organization unless the actor is a Superadmin, or out-ranks BOTH the
+--    target's current and new role within the same org. This blocks self
+--    escalation even through the "Users can update own profile" policy.
+CREATE OR REPLACE FUNCTION public.enforce_profile_privilege()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF NEW.role IS DISTINCT FROM OLD.role
+     OR NEW.organization_id IS DISTINCT FROM OLD.organization_id THEN
+
+    IF public.is_superadmin() THEN
+      RETURN NEW;
+    END IF;
+
+    IF public.my_role_rank() >= 30
+       AND OLD.organization_id = public.get_my_org_id()
+       AND NEW.organization_id = OLD.organization_id          -- non-superadmins can't move orgs
+       AND public.role_rank(OLD.role) < public.my_role_rank()  -- target ranked below me
+       AND public.role_rank(NEW.role) < public.my_role_rank()  -- new role ranked below me
+    THEN
+      RETURN NEW;
+    END IF;
+
+    RAISE EXCEPTION 'You are not allowed to change the role or organization of this user.';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS enforce_profile_privilege_trigger ON public.profiles;
+CREATE TRIGGER enforce_profile_privilege_trigger
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION public.enforce_profile_privilege();


### PR DESCRIPTION
## Summary

Replaces the single `is_admin` "can do everything" flag with a **ranked role hierarchy**, enforced in both RLS and the UI.

`Superadmin(100) > Head Admin(40) > Admin(30) > Manager(20) > Supervisor(10) > Employee(0)`

| Role | Capabilities |
| --- | --- |
| **Head Admin** (owner) | manage locations, invite, assign roles up to Admin, remove lower members |
| **Admin** | invite, assign roles up to Manager (locations: view only) |
| **Manager** | view-only (employees + locations) |
| Supervisor / Employee | no panel access |

**Rules:** you can only act on members ranked below you; assigned role must rank strictly below your own; you can never change your own role/organization. Only Superadmin can grant Head Admin.

### Database (migration `20260617020000_role_hierarchy.sql`)
- Add `rank` to roles; add the **Head Admin** role; backfill ranks.
- `role_rank()` / `my_role_rank()` helpers.
- Drop the old `is_org_admin` policies (they let Managers write).
- Rank-based RLS for locations + profile update/delete.
- `BEFORE UPDATE` trigger blocks self role/organization escalation (defense in depth) — fixes the bug where a Manager could grant themselves Admin.

### Edge Function
- Invite scoping is now rank-based (requires Admin+, invited role must rank strictly below the caller).

### Client
- Roles carry `rank`; new permissions helper drives the UI; forms list only assignable roles; Add/Edit/Delete gated per capability; badge colors for Head Admin / Admin.

### ⚠️ Deploy
- `supabase db push` (new migration) + `supabase functions deploy invite-employee` on each project.
- After deploy, a Superadmin assigns **Head Admin** to organization owners.

✅ `tsc -b` clean · ✅ `vite build` green · ✅ ESLint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCvGiJaoBJEBTG93k2pi5A)_