### PR TITLE
fix(invite): prefetch-proof token_hash verification

### DIFF
--- a/src/features/auth/AcceptInvitePage.tsx
+++ b/src/features/auth/AcceptInvitePage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, type SyntheticEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { BuildingsIcon, IdentificationBadgeIcon, CheckCircleIcon } from '@phosphor-icons/react';
+import { type EmailOtpType } from '@supabase/supabase-js';
 import { supabase } from '@shared/api/supabaseClient';
 import { authService } from './authService';
 import { getRoleBadgeColor } from '@shared/utils/roleColors';
@@ -51,8 +52,11 @@ export function AcceptInvitePage() {
         }
     }, []);
 
-    // The invite token in the URL is processed asynchronously by supabase-js;
-    // listen for the resulting session, with a fallback timeout for bad links.
+    // Two ways to land here:
+    //  1. token_hash flow (preferred): the email link carries ?token_hash&type;
+    //     we verify it on the user's actual click, so email scanners that merely
+    //     GET the page can't burn the one-time token.
+    //  2. Implicit flow: Supabase already put a session in the URL hash.
     useEffect(() => {
         let handled = false;
         const handle = (userId: string) => {
@@ -66,8 +70,23 @@ export function AcceptInvitePage() {
         });
 
         (async () => {
+            const params = new URLSearchParams(window.location.search);
+            const tokenHash = params.get('token_hash');
+            const otpType = params.get('type');
+
+            if (tokenHash && otpType) {
+                const { data, error } = await supabase.auth.verifyOtp({
+                    token_hash: tokenHash,
+                    type: otpType as EmailOtpType,
+                });
+                if (!error && data.session) handle(data.session.user.id);
+                else setStatus('invalid');
+                return;
+            }
+
             const { data: { session } } = await supabase.auth.getSession();
             if (session) return handle(session.user.id);
+
             setTimeout(async () => {
                 if (handled) return;
                 const { data: { session: retry } } = await supabase.auth.getSession();


### PR DESCRIPTION
Email link scanners (e.g. Gmail) prefetch the invite link and burn the one-time token, causing an immediate `otp_expired`. Switches the accept-invite page to the **token_hash flow**: it reads `?token_hash&type` and calls `verifyOtp` on the user's actual click, so a passive GET no longer consumes the token. Implicit hash-session flow kept as fallback.

Requires updating the Supabase **Invite user** email template to link to `/accept-invite?token_hash={{ .TokenHash }}&type=invite`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCvGiJaoBJEBTG93k2pi5A)_