### PR TITLE
fix(auth): keep invitees on /accept-invite (no login bounce)

### DIFF
--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -73,10 +73,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     initAuth();
 
     // Listen for global auth changes (like signing out on another device).
-    const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
-      if (event === 'SIGNED_OUT' || !session) {
+    // Only react to an explicit SIGNED_OUT — an empty INITIAL_SESSION must NOT
+    // bounce to /login (that would break the /accept-invite flow, where the
+    // session only appears after verifyOtp runs).
+    const { data: authListener } = supabase.auth.onAuthStateChange((event) => {
+      if (event === 'SIGNED_OUT') {
         setUser(null);
-        navigate('/login', { replace: true });
+        if (window.location.pathname !== '/accept-invite') {
+          navigate('/login', { replace: true });
+        }
       }
     });
 


### PR DESCRIPTION
The `onAuthStateChange` listener treated any null session as a sign-out and redirected to `/login`, which fired on `/accept-invite` before `verifyOtp` established the session — bouncing invitees to login. Now it only reacts to an explicit `SIGNED_OUT` and never redirects away from `/accept-invite`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCvGiJaoBJEBTG93k2pi5A)_