### PR TITLE
fix(invite): create missing auth.users provisioning trigger

### DIFF
--- a/src/features/auth/AcceptInvitePage.tsx
+++ b/src/features/auth/AcceptInvitePage.tsx
@@ -66,12 +66,20 @@ export function AcceptInvitePage() {
                     token_hash: tokenHash,
                     type: 'invite',
                 });
-                if (error || !data.user) { setStatus('invalid'); return; }
-                await loadFromSession(data.user.id);
-                return;
+                if (!error && data.user) {
+                    // Burn-once: drop the token from the URL so a reload (or a
+                    // double-mount) can't re-submit the now-consumed token and
+                    // bounce the user to "invalid".
+                    window.history.replaceState({}, '', '/accept-invite');
+                    await loadFromSession(data.user.id);
+                    return;
+                }
+                // The token is one-time: a previous load in THIS browser may have
+                // already redeemed it and established the invitee's session. Fall
+                // through to the session check rather than failing outright.
             }
 
-            // Fallback: implicit hash-based flow (no token_hash in the URL).
+            // Implicit hash flow, or recovery of a session redeemed moments ago.
             const { data: { session } } = await supabase.auth.getSession();
             if (session) { await loadFromSession(session.user.id); return; }
 

--- a/supabase/migrations/20260617030000_auth_user_provisioning_trigger.sql
+++ b/supabase/migrations/20260617030000_auth_user_provisioning_trigger.sql
@@ -1,0 +1,22 @@
+-- =============================================================================
+-- AUTH USER PROVISIONING TRIGGER
+-- -----------------------------------------------------------------------------
+-- The handle_new_user() function (see 20260617010000) provisions a profile for
+-- every new auth user, reading the target org + role from invite metadata. It is
+-- only useful if a trigger actually calls it.
+--
+-- On the original project this trigger was created by hand in the dashboard and
+-- never captured in a migration (Supabase's `db dump` omits triggers on the
+-- `auth` schema). Projects bootstrapped purely from migrations (e.g. preprod,
+-- where the base dump was marked applied via `migration repair` rather than run)
+-- therefore had the function but no trigger — so no profile rows were ever
+-- created, and invitees hit "invitation invalid" after a successful verifyOtp.
+--
+-- Create it idempotently so every environment provisions profiles consistently.
+-- =============================================================================
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();


### PR DESCRIPTION
## Real root cause

Invitees saw **"invitation invalid or expired"** even though `verifyOtp` succeeded. The reason wasn't the token — it was that **no `profiles` row was ever created**, so `loadFromSession` failed right after a successful verify and rendered the same error screen.

`handle_new_user()` existed, but **nothing called it**: the `on_auth_user_created` trigger on `auth.users` only ever existed as a hand-made trigger in the original project and was never captured in a migration (`supabase db dump` omits triggers on the `auth` schema). On projects bootstrapped purely from migrations (preprod — base dump marked applied via `migration repair`), the trigger was simply absent.

Confirmed via auth logs: `/verify` → 200 `user_signedup`, then `profiles` query returns 0 rows; `pg_trigger` on `auth.users` was empty.

## Changes

- **Migration `20260617030000`**: create `on_auth_user_created` idempotently (`DROP IF EXISTS` + `CREATE`) so every environment provisions profiles. Already applied to preprod.
- **AcceptInvitePage**: after a successful `verifyOtp`, strip `token_hash` from the URL (burn-once); on verify failure, fall back to an existing session before declaring the link invalid — so a reload/double-mount in the same browser doesn't bounce the user to "expired".

## Test plan
- [x] Trigger applied to preprod; `pg_trigger` now shows `on_auth_user_created`
- [ ] Re-invite a new email → a `profiles` row appears immediately at invite time
- [ ] Click the invite link on the preprod-wired domain → shows org + role → set password → land in app

🤖 Generated with [Claude Code](https://claude.com/claude-code)