### PR TITLE
feat(invite): branded invite email with name, organization & role

### DIFF
--- a/supabase/functions/invite-employee/index.ts
+++ b/supabase/functions/invite-employee/index.ts
@@ -96,7 +96,7 @@ Deno.serve(async (req) => {
         //    strictly below the caller (you can't invite a peer or superior).
         const [{ data: roleRow }, { data: orgRow }] = await Promise.all([
             admin.from('roles').select('name, rank').eq('name', role).single(),
-            admin.from('organizations').select('id').eq('id', organizationId).single(),
+            admin.from('organizations').select('id, name').eq('id', organizationId).single(),
         ]);
         if (!roleRow) return json({ error: `Unknown role "${role}".` }, 400);
         if (!orgRow) return json({ error: 'Unknown organization.' }, 400);
@@ -111,6 +111,7 @@ Deno.serve(async (req) => {
         const { data: invited, error: inviteError } = await admin.auth.admin.inviteUserByEmail(email, {
             data: {
                 organization_id: organizationId,
+                organization_name: orgRow.name, // surfaced in the invite email template
                 role,
                 first_name: firstName,
                 last_name: lastName,

--- a/supabase/templates/invite-user.html
+++ b/supabase/templates/invite-user.html
@@ -1,0 +1,80 @@
+<!--
+  Invite email — Supabase Auth "Invite user" template.
+  Uses the token_hash flow (prefetch-proof) and surfaces the invitee's name,
+  organization and role from the invite metadata set by the invite-employee
+  Edge Function ({{ .Data }} = raw_user_meta_data).
+  Paste the contents into Authentication → Emails → Invite user (Source).
+-->
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f3f4f6;margin:0;padding:32px 12px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+  <tr>
+    <td align="center">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px;background-color:#ffffff;border-radius:18px;overflow:hidden;box-shadow:0 6px 28px rgba(16,24,40,0.08);">
+
+        <!-- Header -->
+        <tr>
+          <td style="background:linear-gradient(135deg,#047857 0%,#10b981 100%);padding:36px 32px;text-align:center;">
+            <div style="font-size:12px;font-weight:700;letter-spacing:2px;text-transform:uppercase;color:#d1fae5;">You've been invited</div>
+            <div style="margin-top:6px;font-size:26px;font-weight:800;color:#ffffff;letter-spacing:-0.5px;">Planuj Směny</div>
+          </td>
+        </tr>
+
+        <!-- Body -->
+        <tr>
+          <td style="padding:32px;">
+            <p style="margin:0 0 18px;font-size:17px;font-weight:600;color:#111827;">
+              {{ with index .Data "first_name" }}Hi {{ . }},{{ else }}Hi there,{{ end }}
+            </p>
+            <p style="margin:0 0 26px;font-size:15px;line-height:1.6;color:#4b5563;">
+              You've been invited to join the team. Set your password to accept and get started.
+            </p>
+
+            <!-- Details card -->
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f9fafb;border:1px solid #eceef1;border-radius:14px;margin-bottom:30px;">
+              <tr>
+                <td style="padding:18px 20px;border-bottom:1px solid #eceef1;">
+                  <div style="font-size:11px;font-weight:700;letter-spacing:1px;text-transform:uppercase;color:#9ca3af;">Organization</div>
+                  <div style="margin-top:5px;font-size:17px;font-weight:700;color:#111827;">{{ index .Data "organization_name" }}</div>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding:18px 20px;">
+                  <div style="font-size:11px;font-weight:700;letter-spacing:1px;text-transform:uppercase;color:#9ca3af;">Role</div>
+                  <div style="margin-top:8px;">
+                    <span style="display:inline-block;background-color:#d1fae5;color:#065f46;font-size:13px;font-weight:700;padding:5px 14px;border-radius:9999px;">{{ index .Data "role" }}</span>
+                  </div>
+                </td>
+              </tr>
+            </table>
+
+            <!-- CTA -->
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+              <tr>
+                <td align="center">
+                  <a href="{{ .SiteURL }}/accept-invite?token_hash={{ .TokenHash }}&type=invite"
+                     style="display:inline-block;background-color:#059669;color:#ffffff;font-size:16px;font-weight:700;text-decoration:none;padding:15px 36px;border-radius:12px;box-shadow:0 4px 14px rgba(5,150,105,0.35);">
+                    Accept invitation
+                  </a>
+                </td>
+              </tr>
+            </table>
+
+            <p style="margin:26px 0 0;font-size:12px;line-height:1.6;color:#9ca3af;text-align:center;">
+              If the button doesn't work, copy and paste this link into your browser:<br>
+              <a href="{{ .SiteURL }}/accept-invite?token_hash={{ .TokenHash }}&type=invite" style="color:#059669;word-break:break-all;">{{ .SiteURL }}/accept-invite?token_hash={{ .TokenHash }}&amp;type=invite</a>
+            </p>
+          </td>
+        </tr>
+
+        <!-- Footer -->
+        <tr>
+          <td style="padding:20px 32px;background-color:#f9fafb;border-top:1px solid #eceef1;text-align:center;">
+            <p style="margin:0;font-size:12px;line-height:1.5;color:#9ca3af;">
+              This invitation was sent to {{ .Email }}.<br>If you weren't expecting it, you can safely ignore this email.
+            </p>
+          </td>
+        </tr>
+
+      </table>
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
## What

A classier invite email that greets the invitee by name and clearly shows the **organization** and **role** they're joining.

- `invite-employee` now includes `organization_name` in the invite metadata (`{{ .Data }}`), alongside the existing org id, role and names.
- New `supabase/templates/invite-user.html` — responsive, inline-styled HTML email (emerald header, org + role card, big CTA, fallback link, footer) using the prefetch-proof token_hash flow.

## Deploy status (already done)
- Edge function deployed: preprod v5, prod v3.
- Email template applied in both Supabase dashboards (preprod + prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)