### PR TITLE
feat(settings): editable username (login) + username in admin + Site-URL-proof invite link

### DIFF
--- a/src/features/admin/AdminPage.tsx
+++ b/src/features/admin/AdminPage.tsx
@@ -521,6 +521,9 @@ function EmployeesList({
                                     </span>
                                 )}
                             </div>
+                            <p className="text-[9px] sm:text-[10px] text-emerald-600 dark:text-emerald-400 font-bold truncate leading-tight">
+                                @{employee.username}
+                            </p>
                             <p className="text-[9px] sm:text-[10px] text-gray-400 font-bold uppercase tracking-tight truncate">
                                 {employee.email}
                             </p>

--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { authService } from './authService';
 import { type User } from '@shared/types';
@@ -15,6 +15,7 @@ interface AuthContextType {
   isLoading: boolean; // True while we are fetching the user profile for the first time.
   isAuthChecking: boolean; // True while we are checking if a session exists (on page load).
   logout: () => Promise<void>; // Function to sign the user out.
+  refreshUser: () => Promise<void>; // Re-fetch the profile (e.g. after editing it in Settings).
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -92,7 +93,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     await authService.signOut();
   };
 
-  const value = { user, isLoading, isAuthChecking, logout };
+  // Re-pull the profile from the DB and update the cached user. Called after the
+  // user edits their own profile (e.g. changes their username in Settings).
+  const refreshUser = useCallback(async () => {
+    const { data: { session } } = await authService.getSession();
+    if (!session) return;
+    const profile = await authService.getUserProfile(session.user.id);
+    if (profile) setUser(profile);
+  }, []);
+
+  const value = { user, isLoading, isAuthChecking, logout, refreshUser };
 
   return (
     <AuthContext.Provider value={value}>

--- a/src/features/auth/authService.ts
+++ b/src/features/auth/authService.ts
@@ -75,5 +75,17 @@ export const authService = {
    */
   async signOut() {
     return await supabase.auth.signOut();
+  },
+
+  /**
+   * Updates the caller's own profile (username is the login identifier).
+   * RLS ("Users can update own profile") restricts this to the user's own row;
+   * the unique_username constraint surfaces as a 23505 error if taken.
+   */
+  async updateProfile(
+    userId: string,
+    fields: { username?: string; first_name?: string | null; last_name?: string | null }
+  ) {
+    return await supabase.from('profiles').update(fields).eq('id', userId);
   }
 };

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -1,54 +1,80 @@
-import { UserIcon, BellIcon, ShieldCheckIcon, PaletteIcon, CaretRightIcon, type Icon } from "@phosphor-icons/react";
-import { useAuthContext } from "@features/auth/AuthContext";
-import { useTheme } from "@app/providers/ThemeContext";
+import { useState, type SyntheticEvent } from 'react';
+import {
+  AtIcon,
+  PaletteIcon,
+  EnvelopeSimpleIcon,
+  IdentificationBadgeIcon,
+  CheckCircleIcon,
+} from '@phosphor-icons/react';
+import { useAuthContext } from '@features/auth/AuthContext';
+import { authService } from '@features/auth/authService';
+import { useTheme } from '@app/providers/ThemeContext';
+import { getRoleBadgeColor } from '@shared/utils/roleColors';
 
 /**
  * --- SETTINGS PAGE ---
- * Unified style with the rest of the app.
+ * Lets the signed-in user edit their own profile. The username is the login
+ * identifier (you can sign in with it instead of your email), so it must stay
+ * unique — the DB unique_username constraint is the source of truth.
  */
 
-interface SettingItem {
-  name: string;
-  icon: Icon;
-  detail?: string;
-  action?: () => void;
-}
-
-interface SettingSection {
-  title: string;
-  items: SettingItem[];
-}
+const USERNAME_RE = /^[a-z0-9._-]{3,30}$/;
 
 export default function SettingsPage() {
-  const { user } = useAuthContext();
+  const { user, refreshUser } = useAuthContext();
   const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
 
-  const sections: SettingSection[] = [
-    {
-      title: 'Personal',
-      items: [
-        { name: 'Profile Information', icon: UserIcon, detail: user?.username },
-        { name: 'Notifications', icon: BellIcon, detail: 'Push, Email' },
-      ]
-    },
-    {
-      title: 'Appearance',
-      items: [
-        { 
-          name: 'Dark Mode', 
-          icon: PaletteIcon, 
-          detail: resolvedTheme === 'dark' ? 'Enabled' : 'Disabled',
-          action: () => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
-        },
-      ]
-    },
-    {
-      title: 'Security',
-      items: [
-        { name: 'Change Password', icon: ShieldCheckIcon, detail: 'Last changed 3mo ago' },
-      ]
+  const [username, setUsername] = useState(user?.username ?? '');
+  const [firstName, setFirstName] = useState(user?.first_name ?? '');
+  const [lastName, setLastName] = useState(user?.last_name ?? '');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  if (!user) return null;
+
+  const normalizedUsername = username.trim().toLowerCase();
+  const dirty =
+    normalizedUsername !== (user.username ?? '') ||
+    firstName.trim() !== (user.first_name ?? '') ||
+    lastName.trim() !== (user.last_name ?? '');
+
+  const handleSubmit = async (e: SyntheticEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSaved(false);
+
+    if (!USERNAME_RE.test(normalizedUsername)) {
+      setError('Username must be 3–30 characters: lowercase letters, numbers, dot, underscore or hyphen.');
+      return;
     }
-  ];
+
+    setBusy(true);
+    const { error: updateError } = await authService.updateProfile(user.id, {
+      username: normalizedUsername,
+      first_name: firstName.trim() || null,
+      last_name: lastName.trim() || null,
+    });
+
+    if (updateError) {
+      setError(
+        updateError.code === '23505'
+          ? 'That username is already taken. Please choose another.'
+          : updateError.message || 'Could not save your changes.',
+      );
+      setBusy(false);
+      return;
+    }
+
+    await refreshUser();
+    setUsername(normalizedUsername);
+    setBusy(false);
+    setSaved(true);
+  };
+
+  const fieldClass =
+    'w-full bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 focus:border-emerald-500 rounded-xl px-3 py-2.5 text-sm outline-none text-gray-900 dark:text-white transition-colors';
 
   return (
     <div className="space-y-6 px-1 max-w-2xl">
@@ -60,52 +86,131 @@ export default function SettingsPage() {
       {/* USER PREVIEW */}
       <div className="p-4 bg-white dark:bg-gray-800/40 border border-gray-100 dark:border-gray-800 rounded-3xl shadow-sm flex items-center gap-4">
         <div className="w-14 h-14 rounded-full bg-emerald-100 dark:bg-emerald-900/40 border-2 border-white dark:border-white/10 flex items-center justify-center text-emerald-700 dark:text-emerald-400 text-lg font-black shrink-0">
-          {user?.first_name?.[0] || user?.username?.[0]}
+          {(user.first_name?.[0] || user.username?.[0] || '?').toUpperCase()}
         </div>
         <div className="min-w-0">
           <h2 className="text-lg font-bold text-gray-900 dark:text-white truncate">
-            {user?.first_name} {user?.last_name}
+            {user.first_name || user.last_name ? `${user.first_name ?? ''} ${user.last_name ?? ''}`.trim() : user.username}
           </h2>
-          <p className="text-[10px] font-bold text-emerald-600 dark:text-emerald-400 uppercase tracking-widest">
-            {user?.role.name} • {user?.organization_id}
-          </p>
+          <div className="flex items-center gap-2 mt-1">
+            <span
+              className={`inline-block px-2 py-0.5 text-[10px] font-black rounded-md uppercase tracking-widest ${getRoleBadgeColor(
+                user.role.name,
+              )}`}
+            >
+              {user.role.name}
+            </span>
+            <span className="text-[11px] text-gray-400 font-bold">@{user.username}</span>
+          </div>
         </div>
       </div>
 
-      <div className="space-y-6 mt-8">
-        {sections.map((section) => (
-          <div key={section.title} className="space-y-2">
-            <h3 className="px-1 text-[10px] font-black text-gray-400 uppercase tracking-[0.2em]">{section.title}</h3>
-            <div className="bg-white dark:bg-gray-800/40 border border-gray-100 dark:border-gray-800 rounded-3xl shadow-sm overflow-hidden">
-              {section.items.map((item, idx) => (
-                <button
-                  key={item.name}
-                  onClick={() => item.action && item.action()}
-                  className={`w-full flex items-center justify-between p-4 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors text-left ${
-                    idx !== section.items.length - 1 ? 'border-b border-gray-50 dark:border-white/5' : ''
-                  }`}
-                >
-                  <div className="flex items-center gap-3 min-w-0">
-                    <div className="w-9 h-9 rounded-xl bg-gray-50 dark:bg-gray-900/50 flex items-center justify-center text-gray-500 dark:text-gray-400 shrink-0">
-                      <item.icon weight="bold" className="w-4 h-4" />
-                    </div>
-                    <div className="min-w-0">
-                      <p className="text-sm font-bold text-gray-900 dark:text-white truncate">{item.name}</p>
-                      <p className="text-[10px] text-gray-400 font-bold uppercase tracking-tight">{item.detail}</p>
-                    </div>
-                  </div>
-                  <CaretRightIcon weight="bold" className="w-4 h-4 text-gray-300 shrink-0" />
-                </button>
-              ))}
+      {/* PROFILE FORM */}
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <h3 className="px-1 text-[10px] font-black text-gray-400 uppercase tracking-[0.2em]">Profile</h3>
+        <div className="bg-white dark:bg-gray-800/40 border border-gray-100 dark:border-gray-800 rounded-3xl shadow-sm p-5 space-y-4">
+          <div>
+            <label className="flex items-center gap-1.5 text-xs font-bold text-gray-600 dark:text-gray-300 mb-1.5">
+              <AtIcon weight="bold" className="w-3.5 h-3.5 text-emerald-500" />
+              Username
+            </label>
+            <input
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="username"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              className={fieldClass}
+            />
+            <p className="text-[11px] text-gray-400 mt-1.5">Used to sign in instead of your email. Must be unique.</p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="text-xs font-bold text-gray-600 dark:text-gray-300 mb-1.5 block">First name</label>
+              <input value={firstName} onChange={(e) => setFirstName(e.target.value)} placeholder="First name" className={fieldClass} />
+            </div>
+            <div>
+              <label className="text-xs font-bold text-gray-600 dark:text-gray-300 mb-1.5 block">Last name</label>
+              <input value={lastName} onChange={(e) => setLastName(e.target.value)} placeholder="Last name" className={fieldClass} />
             </div>
           </div>
-        ))}
+
+          {error && (
+            <p className="text-xs font-bold text-red-500 bg-red-50 dark:bg-red-900/20 rounded-xl px-3 py-2">{error}</p>
+          )}
+          {saved && !error && (
+            <p className="flex items-center gap-1.5 text-xs font-bold text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 rounded-xl px-3 py-2">
+              <CheckCircleIcon weight="fill" className="w-4 h-4" /> Changes saved.
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={busy || !dirty}
+            className="w-full px-4 py-3 rounded-xl font-bold text-sm text-white bg-emerald-500 hover:bg-emerald-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-emerald-500/25"
+          >
+            {busy ? 'Saving…' : 'Save changes'}
+          </button>
+        </div>
+      </form>
+
+      {/* APPEARANCE */}
+      <div className="space-y-2">
+        <h3 className="px-1 text-[10px] font-black text-gray-400 uppercase tracking-[0.2em]">Appearance</h3>
+        <div className="bg-white dark:bg-gray-800/40 border border-gray-100 dark:border-gray-800 rounded-3xl shadow-sm overflow-hidden">
+          <button
+            onClick={() => setTheme(isDark ? 'light' : 'dark')}
+            className="w-full flex items-center justify-between p-4 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors text-left"
+          >
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="w-9 h-9 rounded-xl bg-gray-50 dark:bg-gray-900/50 flex items-center justify-center text-gray-500 dark:text-gray-400 shrink-0">
+                <PaletteIcon weight="bold" className="w-4 h-4" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-bold text-gray-900 dark:text-white">Dark mode</p>
+                <p className="text-[10px] text-gray-400 font-bold uppercase tracking-tight">{isDark ? 'Enabled' : 'Disabled'}</p>
+              </div>
+            </div>
+            <span
+              className={`relative w-11 h-6 rounded-full transition-colors shrink-0 ${isDark ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'}`}
+            >
+              <span
+                className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white transition-transform ${isDark ? 'translate-x-5' : ''}`}
+              />
+            </span>
+          </button>
+        </div>
+      </div>
+
+      {/* ACCOUNT (read-only) */}
+      <div className="space-y-2">
+        <h3 className="px-1 text-[10px] font-black text-gray-400 uppercase tracking-[0.2em]">Account</h3>
+        <div className="bg-white dark:bg-gray-800/40 border border-gray-100 dark:border-gray-800 rounded-3xl shadow-sm overflow-hidden">
+          <div className="flex items-center gap-3 p-4 border-b border-gray-50 dark:border-white/5">
+            <div className="w-9 h-9 rounded-xl bg-gray-50 dark:bg-gray-900/50 flex items-center justify-center text-gray-500 dark:text-gray-400 shrink-0">
+              <EnvelopeSimpleIcon weight="bold" className="w-4 h-4" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-[10px] text-gray-400 font-bold uppercase tracking-tight">Email</p>
+              <p className="text-sm font-bold text-gray-900 dark:text-white truncate">{user.email}</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3 p-4">
+            <div className="w-9 h-9 rounded-xl bg-gray-50 dark:bg-gray-900/50 flex items-center justify-center text-gray-500 dark:text-gray-400 shrink-0">
+              <IdentificationBadgeIcon weight="bold" className="w-4 h-4" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-[10px] text-gray-400 font-bold uppercase tracking-tight">Role</p>
+              <p className="text-sm font-bold text-gray-900 dark:text-white">{user.role.name}</p>
+            </div>
+          </div>
+        </div>
       </div>
 
       <div className="pt-6 text-center">
-        <p className="text-[10px] font-bold text-gray-300 dark:text-gray-600 uppercase tracking-widest">
-          Version 1.0.4 • 2026
-        </p>
+        <p className="text-[10px] font-bold text-gray-300 dark:text-gray-600 uppercase tracking-widest">Version 1.0.4 • 2026</p>
       </div>
     </div>
   );

--- a/supabase/templates/invite-user.html
+++ b/supabase/templates/invite-user.html
@@ -3,6 +3,10 @@
   Uses the token_hash flow (prefetch-proof) and surfaces the invitee's name,
   organization and role from the invite metadata set by the invite-employee
   Edge Function ({{ .Data }} = raw_user_meta_data).
+
+  The link host comes from {{ .RedirectTo }} (the redirect_to the function
+  passes = "<app origin>/accept-invite"), NOT {{ .SiteURL }} — so it is immune
+  to the Vercel↔Supabase integration overwriting the dashboard Site URL.
   Paste the contents into Authentication → Emails → Invite user (Source).
 -->
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f3f4f6;margin:0;padding:32px 12px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
@@ -50,7 +54,7 @@
             <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
               <tr>
                 <td align="center">
-                  <a href="{{ .SiteURL }}/accept-invite?token_hash={{ .TokenHash }}&type=invite"
+                  <a href="{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=invite"
                      style="display:inline-block;background-color:#059669;color:#ffffff;font-size:16px;font-weight:700;text-decoration:none;padding:15px 36px;border-radius:12px;box-shadow:0 4px 14px rgba(5,150,105,0.35);">
                     Accept invitation
                   </a>
@@ -60,7 +64,7 @@
 
             <p style="margin:26px 0 0;font-size:12px;line-height:1.6;color:#9ca3af;text-align:center;">
               If the button doesn't work, copy and paste this link into your browser:<br>
-              <a href="{{ .SiteURL }}/accept-invite?token_hash={{ .TokenHash }}&type=invite" style="color:#059669;word-break:break-all;">{{ .SiteURL }}/accept-invite?token_hash={{ .TokenHash }}&amp;type=invite</a>
+              <a href="{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=invite" style="color:#059669;word-break:break-all;">{{ .RedirectTo }}?token_hash={{ .TokenHash }}&amp;type=invite</a>
             </p>
           </td>
         </tr>


### PR DESCRIPTION
## What

Addresses three things:

1. **Settings page is now functional.** Users can edit their **username** (the login identifier — you can sign in with it instead of email), plus first/last name. Format-validated, surfaces the unique-username conflict, refreshes the cached profile on save.
2. **Admin panel shows `@username`** on each member card.
3. **Invite link no longer depends on the dashboard Site URL.** The Vercel↔Supabase integration keeps overwriting preprod's Site URL back to the generic deployment alias, which broke the email link. The template now builds the link from `{{ .RedirectTo }}` (the `redirect_to` the Edge Function passes = `<app origin>/accept-invite`), making it immune to those reverts.

## Notes
- `authService.updateProfile()` writes the own-profile row (allowed by the existing `Users can update own profile` RLS policy; the `enforce_profile_privilege` trigger only guards role/org, not username).
- Email template change must also be applied in both Supabase dashboards (preprod + prod) — done out of band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)