### PR TITLE
refactor(phase0): shift bug fixes + unify admin authorization on rank

### DIFF
--- a/src/features/admin/permissions.ts
+++ b/src/features/admin/permissions.ts
@@ -18,6 +18,16 @@ export function isSuperAdmin(user: Pick<User, 'role'>): boolean {
     return user.role.name === 'Superadmin';
 }
 
+/**
+ * May open the admin panel. Manager and above can VIEW it (read-only for
+ * Manager); write capabilities are gated separately (canManageEmployees /
+ * canManageLocations) and enforced by RLS. Single source of truth for the
+ * /admin route guard and the nav item — replaces the legacy `is_admin` flag.
+ */
+export function canViewAdminPanel(user: Pick<User, 'role'>): boolean {
+    return user.role.rank >= RANK.MANAGER;
+}
+
 /** Admin level or above: may invite and manage lower-ranked members. */
 export function canManageEmployees(user: Pick<User, 'role'>): boolean {
     return user.role.rank >= RANK.ADMIN;

--- a/src/features/auth/RoleGuards.tsx
+++ b/src/features/auth/RoleGuards.tsx
@@ -1,17 +1,18 @@
 import { Navigate, Outlet } from 'react-router-dom';
 import { useAuthContext } from './AuthContext';
-
+import { canViewAdminPanel } from '@features/admin/permissions';
 
 export function RoleGuard() {
     const { user, isLoading, isAuthChecking } = useAuthContext();
 
     // 1. Wait until we actually know who the user is
     if (isLoading || isAuthChecking) {
-        return <div className="flex h-screen items-center justify-center">Loading...</div>;
+        return <div className="flex min-h-dvh items-center justify-center">Loading...</div>;
     }
 
-    // 2. If no user is logged in, or their role is NOT in the allowed list, kick them out
-    if (!user || !user.role.is_admin) {
+    // 2. Gate on the role hierarchy (Manager+). is_admin is legacy and was
+    //    inconsistent with the rank-based model used everywhere else.
+    if (!user || !canViewAdminPanel(user)) {
         return <Navigate to="/" replace />;
     }
 

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -8,6 +8,7 @@ import { useAuthContext } from '@features/auth/AuthContext';
 import { useShiftContext } from '@features/shifts/ShiftContext';
 import { useTheme } from '@app/providers/ThemeContext';
 import { LocationSelection } from '@features/locations/components/LocationSelection';
+import { canViewAdminPanel } from '@features/admin/permissions';
 
 /**
  * --- DASHBOARD COMPONENT ---
@@ -49,7 +50,7 @@ export function Dashboard({ onLocationSelect }: DashboardProps) {
     { name: 'Dashboard', icon: SquaresFourIcon, route: '/' },
     { name: 'Overview', icon: ChartBarIcon, route: '/overview' },
     { name: 'My Shifts', icon: ClockIcon, route: '/my-shifts' },
-    ...(user?.role.is_admin ? [{ name: 'Admin Panel', icon: ShieldCheckIcon, route: '/admin' }] : []),
+    ...(user && canViewAdminPanel(user) ? [{ name: 'Admin Panel', icon: ShieldCheckIcon, route: '/admin' }] : []),
     { name: 'Settings', icon: GearIcon, route: '/settings' }
   ];
 

--- a/src/features/shifts/hooks/useRealtime.ts
+++ b/src/features/shifts/hooks/useRealtime.ts
@@ -14,7 +14,7 @@ import { Capacitor, type PluginListenerHandle } from '@capacitor/core';
 
 interface RealtimeParams {
   user: User | null;
-  setActiveShift: (shift: Shift | null) => void;
+  setActiveShift: React.Dispatch<React.SetStateAction<Shift | null>>;
   setSelectedLocationId: (id: string | null) => void;
   setAllActiveShifts: React.Dispatch<React.SetStateAction<Shift[]>>;
   setUserShifts: React.Dispatch<React.SetStateAction<Shift[]>>;
@@ -117,10 +117,14 @@ export function useRealtime({
               }
             }
           } else if (payload.eventType === 'DELETE') {
-            if (payload.old.id === user.id) {
-              setActiveShift(null);
-            }
-            setAllActiveShifts(prev => prev.filter(s => s.id !== payload.old.id));
+            // Postgres DELETE payloads carry only the primary key (unless the
+            // table is REPLICA IDENTITY FULL), so match the deleted shift by id
+            // and clear our active shift if it was the one removed. (The old
+            // code compared shift.id to user.id — always false.)
+            const deletedId = payload.old?.id;
+            if (!deletedId) return;
+            setAllActiveShifts((prev) => prev.filter((s) => s.id !== deletedId));
+            setActiveShift((prev) => (prev && prev.id === deletedId ? null : prev));
           }
         }
       )

--- a/src/features/shifts/hooks/useShifts.ts
+++ b/src/features/shifts/hooks/useShifts.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { shiftService } from '../shiftService';
 import { locationService } from '@features/locations/locationService';
 import { type Shift, type Location, type User } from '@shared/types';
@@ -54,20 +54,27 @@ export function useShifts(user: User | null) {
     }
   }, [user?.id, user?.role, user?.organization_id]);
 
-  // Load everything on startup.
+  // Load everything on startup (and whenever the identified user changes, since
+  // refreshData is keyed on user id/org/role). We deliberately DON'T depend on
+  // locations.length — that caused a second full fetch right after the first
+  // load populated locations (0 -> N re-triggered the effect). The spinner only
+  // shows on the very first load to avoid flicker during background refreshes.
+  const hasLoadedOnce = useRef(false);
   useEffect(() => {
+    let cancelled = false;
     const init = async () => {
-      // Only show loading if we don't have any locations yet (initial load).
-      // This prevents the UI from "flickering" or showing spinners during background refreshes.
-      if (locations.length === 0) {
-        setIsLoading(true);
-      }
-      
+      if (!hasLoadedOnce.current) setIsLoading(true);
       await refreshData();
-      setIsLoading(false);
+      if (!cancelled) {
+        hasLoadedOnce.current = true;
+        setIsLoading(false);
+      }
     };
     init();
-  }, [refreshData, locations.length]);
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshData]);
 
   /**
    * ACTION: START SHIFT


### PR DESCRIPTION
Phase 0 of the refactor — part 1 (safe, frontend-only).

- **S2** Admin panel access now uses the role hierarchy (`canViewAdminPanel` = rank ≥ Manager) in `RoleGuard` and the nav, replacing the legacy `is_admin` flag that was inconsistent with the rank model. Real writes remain gated by RLS.
- **L1** Fixed double initial fetch in `useShifts` (init effect depended on `locations.length`, so 0→N re-triggered a second 4-query refresh).
- **L2** Fixed realtime DELETE handler (compared `shift.id` to `user.id` — always false); now matches by PK and clears `activeShift` if removed.

Verified: `tsc -b`, `eslint` (0 errors), `vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)