### PR TITLE
refactor(phase0): surface shift action errors (L4)

### DIFF
--- a/src/app/layout/AppShell.tsx
+++ b/src/app/layout/AppShell.tsx
@@ -1,5 +1,7 @@
-import { AnimatePresence } from 'framer-motion';
+import { useEffect } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 import { Outlet } from 'react-router-dom';
+import { WarningCircleIcon, XIcon } from '@phosphor-icons/react';
 
 import { useAuthContext } from '@features/auth/AuthContext';
 import { useShiftContext } from '@features/shifts/ShiftContext';
@@ -33,7 +35,14 @@ export interface AppOutletContext {
 
 export function AppShell() {
   const { user, isAuthChecking, isLoading: isAuthLoading } = useAuthContext();
-  const { activeShift, allActiveShifts, locations, selectedLocationId, setSelectedLocationId } = useShiftContext();
+  const { activeShift, allActiveShifts, locations, selectedLocationId, setSelectedLocationId, actionError, clearActionError } = useShiftContext();
+
+  // Auto-dismiss the shift-action error toast after a few seconds.
+  useEffect(() => {
+    if (!actionError) return;
+    const t = setTimeout(clearActionError, 5000);
+    return () => clearTimeout(t);
+  }, [actionError, clearActionError]);
 
   // Location switch/confirm logic hook.
   const { isLocationPopupOpen, setIsLocationPopupOpen, pendingLocation, handleLocationSelect } = useLocationManagement({
@@ -69,6 +78,27 @@ export function AppShell() {
       <main className="flex-1 p-3 pb-40 md:p-6 md:pb-6 max-w-7xl transition-all">
         <Outlet context={contextValue} />
       </main>
+
+      {/* ACTION ERROR TOAST — surfaces failed shift actions (start/end/move). */}
+      <AnimatePresence>
+        {actionError && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 20 }}
+            role="alert"
+            className="fixed left-1/2 -translate-x-1/2 z-[200] bottom-[calc(5.5rem+env(safe-area-inset-bottom))] md:bottom-6 w-[calc(100%-2rem)] max-w-md"
+          >
+            <div className="flex items-start gap-3 bg-red-500 text-white rounded-2xl px-4 py-3 shadow-2xl shadow-red-500/30">
+              <WarningCircleIcon weight="fill" className="w-5 h-5 shrink-0 mt-0.5" />
+              <p className="flex-1 text-sm font-bold leading-snug">{actionError}</p>
+              <button onClick={clearActionError} aria-label="Dismiss" className="shrink-0 -m-1 p-1 hover:bg-white/20 rounded-lg transition-colors">
+                <XIcon weight="bold" className="w-4 h-4" />
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* GLOBAL OVERLAYS */}
       <AnimatePresence>

--- a/src/features/shifts/ShiftContext.tsx
+++ b/src/features/shifts/ShiftContext.tsx
@@ -28,6 +28,8 @@ interface ShiftContextType {
   handleEndShift: () => Promise<void>;
   handleChangeLocation: (newLocationId: string) => Promise<void>;
   refreshData: () => Promise<void>;
+  actionError: string | null;
+  clearActionError: () => void;
 }
 
 const ShiftContext = createContext<ShiftContextType | undefined>(undefined);

--- a/src/features/shifts/hooks/useShifts.ts
+++ b/src/features/shifts/hooks/useShifts.ts
@@ -21,6 +21,9 @@ export function useShifts(user: User | null) {
   const [isEnding, setIsEnding] = useState(false);
   const [isChangingLocation, setIsChangingLocation] = useState(false);
   const [selectedLocationId, setSelectedLocationId] = useState<string | null>(null);
+  // Surfaced to the UI (toast in AppShell) so failed actions aren't silent.
+  const [actionError, setActionError] = useState<string | null>(null);
+  const clearActionError = useCallback(() => setActionError(null), []);
 
   /**
    * REFRESH DATA: Fetches everything from the database.
@@ -83,12 +86,14 @@ export function useShifts(user: User | null) {
     if (!selectedLocationId || !user || isStarting) return;
     try {
       setIsStarting(true);
+      setActionError(null);
       const data = await shiftService.startShift(user, selectedLocationId);
       setActiveShift(data);
       // Optimistically update lists
       setAllActiveShifts(prev => [...prev, { ...data, profiles: { username: user.username, first_name: user.first_name, last_name: user.last_name } } as Shift]);
     } catch (err) {
       console.error('Error starting shift:', err);
+      setActionError(err instanceof Error ? err.message : 'Could not start your shift. Please try again.');
     } finally {
       setIsStarting(false);
     }
@@ -101,6 +106,7 @@ export function useShifts(user: User | null) {
     if (!activeShift || isEnding) return;
     try {
       setIsEnding(true);
+      setActionError(null);
       const endedShift = await shiftService.endShift(activeShift.id);
       setActiveShift(null);
       setSelectedLocationId(null);
@@ -110,6 +116,7 @@ export function useShifts(user: User | null) {
       setUserShifts(prev => [endedShift, ...prev]);
     } catch (err) {
       console.error('Error ending shift:', err);
+      setActionError(err instanceof Error ? err.message : 'Could not end your shift. Please try again.');
     } finally {
       setIsEnding(false);
     }
@@ -123,6 +130,7 @@ export function useShifts(user: User | null) {
     if (!activeShift || isChangingLocation) return;
     try {
       setIsChangingLocation(true);
+      setActionError(null);
       // We pass the current location as the 'previous' one before it gets updated.
       const updatedShift = await shiftService.changeShiftLocation(
         activeShift.id,
@@ -135,6 +143,7 @@ export function useShifts(user: User | null) {
       setSelectedLocationId(newLocationId);
     } catch (err) {
       console.error('Error changing shift location:', err);
+      setActionError(err instanceof Error ? err.message : 'Could not change location. Please try again.');
     } finally {
       setIsChangingLocation(false);
     }
@@ -157,6 +166,8 @@ export function useShifts(user: User | null) {
     handleStartShift,
     handleEndShift,
     handleChangeLocation,
-    refreshData
+    refreshData,
+    actionError,
+    clearActionError
   };
 }


### PR DESCRIPTION
Adds a dismissible error toast for failed shift actions (start/end/move), which previously failed silently (console.error only). `actionError` lives in the shifts hook and is rendered globally in AppShell above the mobile action bar.

Verified: tsc, eslint (0 errors), vite build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)