### PR TITLE
fix(security): secure username login + kill enumeration (S1)

### DIFF
--- a/src/features/auth/LoginPage.tsx
+++ b/src/features/auth/LoginPage.tsx
@@ -38,30 +38,23 @@ export function LoginPage() {
     setErrorMsg('');
 
     try {
-      let emailToUse = loginInput.trim();
+      const input = loginInput.trim();
 
-      // IF: The user didn't type an '@', we assume it's a username and try to find their email.
-      if (!emailToUse.includes('@')) {
-        const foundEmail = await authService.getEmailByUsername(emailToUse);
-        if (!foundEmail) {
-          throw new Error('User not found. Please check your username.');
-        }
-        emailToUse = foundEmail;
+      if (input.includes('@')) {
+        // Email + password: Supabase already returns a generic error on failure.
+        const { error } = await authService.signIn(input, password);
+        if (error) throw error;
+      } else {
+        // Username: resolved + verified server-side (no email/username leak).
+        await authService.signInWithUsername(input, password);
       }
 
-      // Perform the actual sign-in.
-      const { data, error } = await authService.signIn(emailToUse, password);
-      if (error) throw error;
-
-      if (data.user) {
-        // Successful login! Redirect to home page.
-        navigate('/', { replace: true });
-      }
+      navigate('/', { replace: true });
     }
-    catch (error: unknown) {
-      // Show error message on screen for the user.
-      setErrorMsg((error instanceof Error ? error.message : "Authorization error") || "Authorization error")
-      console.error(error)
+    catch (error) {
+      // Single generic message — never reveal whether the account exists.
+      console.error(error);
+      setErrorMsg('Invalid email/username or password.');
     }
     finally {
       setIsLoading(false)

--- a/src/features/auth/authService.ts
+++ b/src/features/auth/authService.ts
@@ -49,15 +49,24 @@ export const authService = {
   },
 
   /**
-   * If a user logs in with a username, we need to find their email first.
-   * We use a custom DB function (RPC) called 'get_email_by_username'.
+   * Sign in with a username. The username -> email resolution AND the sign-in
+   * happen inside the `username-login` Edge Function so the username/email map
+   * is never exposed to the client (no enumeration / PII leak). On success the
+   * returned tokens are adopted as the local session.
    */
-  async getEmailByUsername(username: string): Promise<string | null> {
-    const { data, error } = await supabase.rpc('get_email_by_username', {
-      u_name: username
+  async signInWithUsername(username: string, password: string): Promise<void> {
+    const { data, error } = await supabase.functions.invoke('username-login', {
+      body: { username, password },
     });
-    if (error) throw error;
-    return data;
+    // Any non-2xx (FunctionsHttpError) or missing tokens => generic failure.
+    if (error || !data?.access_token || !data?.refresh_token) {
+      throw new Error('Invalid username or password.');
+    }
+    const { error: sessionError } = await supabase.auth.setSession({
+      access_token: data.access_token,
+      refresh_token: data.refresh_token,
+    });
+    if (sessionError) throw sessionError;
   },
 
   /**

--- a/supabase/functions/username-login/index.ts
+++ b/supabase/functions/username-login/index.ts
@@ -1,0 +1,82 @@
+// =============================================================================
+// EDGE FUNCTION: username-login   (verify_jwt = false — this IS the login)
+// -----------------------------------------------------------------------------
+// Lets users sign in with a username instead of an email WITHOUT exposing the
+// username -> email mapping to the public.
+//
+// Previously the client called the `get_email_by_username` RPC (granted to
+// `anon`) to turn a username into an email, then signed in. That let anyone
+// enumerate usernames and harvest email addresses (PII).
+//
+// Here the lookup AND the sign-in happen server-side; the response only ever
+// contains session tokens or a single generic error, so it leaks neither which
+// usernames exist nor any email address.
+// =============================================================================
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+function json(body: unknown, status = 200) {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+}
+
+const GENERIC = 'Invalid username or password.';
+
+Deno.serve(async (req) => {
+    if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+    if (req.method !== 'POST') return json({ error: 'Method not allowed.' }, 405);
+
+    try {
+        const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+        const ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY')!;
+        const SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+        const body = await req.json().catch(() => ({}));
+        const username = String(body.username ?? '').trim();
+        const password = String(body.password ?? '');
+        if (!username || !password) return json({ error: GENERIC }, 400);
+
+        // 1. Resolve username -> email with the service role (never returned).
+        const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+            auth: { autoRefreshToken: false, persistSession: false },
+        });
+        const { data: profile } = await admin
+            .from('profiles')
+            .select('email')
+            .eq('username', username)
+            .maybeSingle();
+
+        // Same generic error whether the username exists or not (no oracle).
+        if (!profile?.email) return json({ error: GENERIC }, 400);
+
+        // 2. Verify the password by actually signing in (anon client).
+        const authClient = createClient(SUPABASE_URL, ANON_KEY, {
+            auth: { autoRefreshToken: false, persistSession: false },
+        });
+        const { data, error } = await authClient.auth.signInWithPassword({
+            email: profile.email,
+            password,
+        });
+        if (error || !data.session) return json({ error: GENERIC }, 400);
+
+        // 3. Return only the tokens; the client adopts them via setSession().
+        return json(
+            {
+                access_token: data.session.access_token,
+                refresh_token: data.session.refresh_token,
+            },
+            200,
+        );
+    } catch {
+        // Never leak internals on the login path.
+        return json({ error: GENERIC }, 400);
+    }
+});

--- a/supabase/migrations/20260617040000_revoke_get_email_by_username.sql
+++ b/supabase/migrations/20260617040000_revoke_get_email_by_username.sql
@@ -1,0 +1,15 @@
+-- =============================================================================
+-- LOCK DOWN get_email_by_username  (S1 — close the username/email enumeration)
+-- -----------------------------------------------------------------------------
+-- This RPC returned an email for any username and was granted to `anon`, letting
+-- anyone enumerate usernames and harvest emails (PII). Username login now goes
+-- through the `username-login` Edge Function (service_role lookup + sign-in,
+-- generic errors), so no client needs this RPC. Revoke all caller access.
+--
+-- Apply ONLY after the Edge-Function login is confirmed working, so username
+-- sign-in never has a window where neither path works.
+-- =============================================================================
+
+REVOKE EXECUTE ON FUNCTION public.get_email_by_username(text) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.get_email_by_username(text) FROM authenticated;
+REVOKE EXECUTE ON FUNCTION public.get_email_by_username(text) FROM public;


### PR DESCRIPTION
Closes the username->email enumeration / PII leak.

- New `username-login` Edge Function (verify_jwt=false): resolves email via service_role and signs in server-side; returns only tokens or a generic error. Deployed to preprod + prod.
- `authService.signInWithUsername` adopts the tokens via `setSession`; `getEmailByUsername` removed; `LoginPage` shows one generic error (no existence oracle).
- Migration `20260617040000` revokes the legacy `get_email_by_username` RPC from anon/authenticated/public — **applied only after** the new login is confirmed (gated).

Smoke-tested: function returns generic 400 for unknown/empty input. Verified tsc/eslint/build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)