### PR TITLE
refactor(phase2): declarative route guards (A1) + error boundary (A2)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import { ThemeProvider } from './app/providers/ThemeContext';
 // App Shell (eager — it is the persistent frame around every page).
 import { AppShell } from './app/layout/AppShell';
 import { RoleGuard } from './features/auth/RoleGuards';
+import { ProtectedRoute, PublicRoute } from './app/router/RouteGuards';
+import { ErrorBoundary } from './shared/components/ErrorBoundary';
 import { PageLoader } from './shared/components/PageLoader';
 
 /**
@@ -35,32 +37,40 @@ const SettingsPage = lazy(() => import('./features/settings/SettingsPage'));
 
 export default function App() {
   return (
-    <ThemeProvider>
-      <AuthProvider>
-        <ShiftProvider>
-          <Suspense fallback={<PageLoader />}>
-            <Routes>
-              {/* 1. PUBLIC ROUTES: Available to everyone. */}
-              <Route path="/login" element={<LoginPage />} />
-              <Route path="/accept-invite" element={<AcceptInvitePage />} />
+    <ErrorBoundary>
+      <ThemeProvider>
+        <AuthProvider>
+          <ShiftProvider>
+            <Suspense fallback={<PageLoader />}>
+              <Routes>
+                {/* PUBLIC: invite acceptance manages its own session (no guard). */}
+                <Route path="/accept-invite" element={<AcceptInvitePage />} />
 
-              {/* 2. PROTECTED ROUTES: Only for logged-in users. */}
-              <Route path="/" element={<AppShell />}>
-                <Route index element={<HomePage />} />
-                <Route path="overview" element={<OverviewPage />} />
-                <Route path="my-shifts" element={<MyShiftsPage />} />
-                <Route element={<RoleGuard />}>
-                  <Route path="admin" element={<AdminPage />} />
+                {/* LOGGED-OUT ONLY: redirects to "/" if already authenticated. */}
+                <Route element={<PublicRoute />}>
+                  <Route path="/login" element={<LoginPage />} />
                 </Route>
-                <Route path="settings" element={<SettingsPage />} />
-              </Route>
 
-              {/* 3. FALLBACK: Redirect any unknown URL to Home. */}
-              <Route path="*" element={<Navigate to="/" replace />} />
-            </Routes>
-          </Suspense>
-        </ShiftProvider>
-      </AuthProvider>
-    </ThemeProvider>
+                {/* PROTECTED: requires a session; redirects to "/login" otherwise. */}
+                <Route element={<ProtectedRoute />}>
+                  <Route path="/" element={<AppShell />}>
+                    <Route index element={<HomePage />} />
+                    <Route path="overview" element={<OverviewPage />} />
+                    <Route path="my-shifts" element={<MyShiftsPage />} />
+                    <Route element={<RoleGuard />}>
+                      <Route path="admin" element={<AdminPage />} />
+                    </Route>
+                    <Route path="settings" element={<SettingsPage />} />
+                  </Route>
+                </Route>
+
+                {/* FALLBACK: any unknown URL -> Home (then guards take over). */}
+                <Route path="*" element={<Navigate to="/" replace />} />
+              </Routes>
+            </Suspense>
+          </ShiftProvider>
+        </AuthProvider>
+      </ThemeProvider>
+    </ErrorBoundary>
   );
 }

--- a/src/app/router/RouteGuards.tsx
+++ b/src/app/router/RouteGuards.tsx
@@ -1,0 +1,30 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuthContext } from '@features/auth/AuthContext';
+import { PageLoader } from '@shared/components/PageLoader';
+
+/**
+ * --- ROUTE GUARDS ---
+ * Declarative auth gating. These render-time guards replace the imperative
+ * navigate() calls that used to live in AuthContext / LoginPage, so there is one
+ * predictable place that decides where an un/authenticated user may go (no races,
+ * no content flashing before a redirect).
+ *
+ * Note: /accept-invite is intentionally NOT wrapped by either guard — it manages
+ * its own session (verifyOtp) and must stay reachable while logged out.
+ */
+
+/** Pages that require a session (the whole app shell). */
+export function ProtectedRoute() {
+  const { user, isAuthChecking } = useAuthContext();
+  if (isAuthChecking) return <PageLoader />;
+  if (!user) return <Navigate to="/login" replace />;
+  return <Outlet />;
+}
+
+/** Pages only for logged-OUT users (the login screen). */
+export function PublicRoute() {
+  const { user, isAuthChecking } = useAuthContext();
+  if (isAuthChecking) return <PageLoader />;
+  if (user) return <Navigate to="/" replace />;
+  return <Outlet />;
+}

--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -1,100 +1,83 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { authService } from './authService';
 import { type User } from '@shared/types';
 import { supabase } from '@shared/api/supabaseClient';
 
 /**
  * --- AUTH CONTEXT ---
- * This file handles the global "state" of who is logged in.
- * Any component in the app can ask "who is the user?" using the useAuthContext() hook.
+ * Single source of truth for "who is logged in". It only exposes STATE — it no
+ * longer navigates. Routing decisions live in the declarative route guards
+ * (ProtectedRoute / PublicRoute), which removes the old races where AuthContext,
+ * LoginPage and the guards all tried to redirect.
  */
 
 interface AuthContextType {
-  user: User | null; // The logged-in user object or null if not logged in.
-  isLoading: boolean; // True while we are fetching the user profile for the first time.
-  isAuthChecking: boolean; // True while we are checking if a session exists (on page load).
-  logout: () => Promise<void>; // Function to sign the user out.
-  refreshUser: () => Promise<void>; // Re-fetch the profile (e.g. after editing it in Settings).
+  user: User | null; // The logged-in user, or null.
+  isLoading: boolean; // True during the first profile load.
+  isAuthChecking: boolean; // True until the initial session check resolves.
+  logout: () => Promise<void>;
+  refreshUser: () => Promise<void>; // Re-pull the profile (e.g. after editing it).
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const navigate = useNavigate();
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isAuthChecking, setIsAuthChecking] = useState(true);
 
-  // Initial setup: Check if the user is already logged in (Restore session).
   useEffect(() => {
-    const initAuth = async () => {
+    let active = true;
+
+    const loadProfile = async (userId: string) => {
       try {
-        // The invite-acceptance page handles its own session (set from the URL).
-        // Don't bounce the invitee to /login while that page is processing.
-        if (window.location.pathname === '/accept-invite') {
-          return;
-        }
-
-        const { data: { session }, error: sessionError } = await authService.getSession();
-
-        // If no session or error, go to the login page.
-        if (sessionError || !session) {
-          navigate('/login', { replace: true });
-          return;
-        }
-
-        // Fetch user profile based on the ID from the session.
-        try {
-          const profile = await authService.getUserProfile(session.user.id);
-          if (profile) {
-            setUser(profile);
-          } else {
-            // Profile not found in DB - this should not happen but we handle it.
-            console.warn('Profile not found, signing out.');
-            await authService.signOut();
-            navigate('/login', { replace: true });
-          }
-        } catch (profileErr) {
-          console.error('Failed to load profile:', profileErr);
-          // If we have a session but profile fetch fails (e.g., network error),
-          // we don't clear the session but we should show an error or try again.
-          // For now, let's keep the user at the loading state or redirect.
-          await authService.signOut();
-          navigate('/login', { replace: true });
-        }
+        const profile = await authService.getUserProfile(userId);
+        if (active) setUser(profile ?? null);
       } catch (err) {
-        console.error('Error initAuth:', err);
-      } finally {
-        setIsLoading(false);
-        setIsAuthChecking(false);
+        console.error('Failed to load profile:', err);
+        if (active) setUser(null);
       }
     };
 
-    initAuth();
-
-    // Listen for global auth changes (like signing out on another device).
-    // Only react to an explicit SIGNED_OUT — an empty INITIAL_SESSION must NOT
-    // bounce to /login (that would break the /accept-invite flow, where the
-    // session only appears after verifyOtp runs).
-    const { data: authListener } = supabase.auth.onAuthStateChange((event) => {
-      if (event === 'SIGNED_OUT') {
-        setUser(null);
-        if (window.location.pathname !== '/accept-invite') {
-          navigate('/login', { replace: true });
+    // 1. Initial session restore — flip isAuthChecking only AFTER the profile is
+    //    loaded, so guards never see "session but no user" and bounce wrongly.
+    (async () => {
+      try {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (session) await loadProfile(session.user.id);
+        else if (active) setUser(null);
+      } finally {
+        if (active) {
+          setIsLoading(false);
+          setIsAuthChecking(false);
         }
       }
+    })();
+
+    // 2. React to later auth changes: login, logout, token refresh, and the
+    //    session the /accept-invite page establishes via verifyOtp. INITIAL_SESSION
+    //    is handled by the restore above, so we skip it here to avoid a double fetch.
+    const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'INITIAL_SESSION') return;
+      if (event === 'SIGNED_OUT' || !session) {
+        setUser(null);
+        return;
+      }
+      loadProfile(session.user.id);
     });
 
-    return () => authListener.subscription.unsubscribe();
-  }, [navigate]);
+    return () => {
+      active = false;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
 
-  const logout = async () => {
+  // Sign out; the SIGNED_OUT listener clears the user and the guard redirects.
+  const logout = useCallback(async () => {
     await authService.signOut();
-  };
+  }, []);
 
-  // Re-pull the profile from the DB and update the cached user. Called after the
-  // user edits their own profile (e.g. changes their username in Settings).
+  // Re-fetch the profile and update the cached user (used after Settings edits).
   const refreshUser = useCallback(async () => {
     const { data: { session } } = await authService.getSession();
     if (!session) return;
@@ -104,16 +87,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const value = { user, isLoading, isAuthChecking, logout, refreshUser };
 
-  return (
-    <AuthContext.Provider value={value}>
-      {children}
-    </AuthContext.Provider>
-  );
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
 /**
  * CUSTOM HOOK: useAuthContext
- * This allows any component to easily access the authentication state.
+ * Lets any component read the authentication state.
  */
 export function useAuthContext() {
   const context = useContext(AuthContext);

--- a/src/features/auth/LoginPage.tsx
+++ b/src/features/auth/LoginPage.tsx
@@ -1,37 +1,19 @@
-import { useState, useEffect, type SyntheticEvent } from "react";
-import { useNavigate } from "react-router-dom";
+import { useState, type SyntheticEvent } from "react";
 import { authService } from './authService'
 
 /**
  * --- LOGIN PAGE ---
- * This is the first screen users see if they aren't logged in.
- * It handles both email and username logins.
+ * Pure sign-in form. Redirecting an already-authenticated user away, and
+ * redirecting in after a successful login, are both handled declaratively by
+ * <PublicRoute> — this component no longer navigates itself.
  */
 
 export function LoginPage() {
-  const navigate = useNavigate()
-
-  // LOCAL STATE: We store the input values and error messages.
   const [loginInput, setLoginInput] = useState('');
   const [password, setPassword] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  const [isAuthChecking, setIsAuthChecking] = useState(true)
 
-  // 1. Initial Check: If user already has a valid session, skip login and go to home.
-  useEffect(() => {
-    const checkUser = async () => {
-      const { data: { session } } = await authService.getSession();
-      if (session) {
-        navigate('/', { replace: true });
-      } else {
-        setIsAuthChecking(false);
-      }
-    };
-    checkUser()
-  }, [navigate])
-
-  // 2. Form submission handler.
   const handleLogin = async (e: SyntheticEvent) => {
     e.preventDefault();
     setIsLoading(true);
@@ -41,37 +23,26 @@ export function LoginPage() {
       const input = loginInput.trim();
 
       if (input.includes('@')) {
-        // Email + password: Supabase already returns a generic error on failure.
+        // Email + password — Supabase already returns a generic error on failure.
         const { error } = await authService.signIn(input, password);
         if (error) throw error;
       } else {
-        // Username: resolved + verified server-side (no email/username leak).
+        // Username — resolved + verified server-side (no email/username leak).
         await authService.signInWithUsername(input, password);
       }
 
-      navigate('/', { replace: true });
-    }
-    catch (error) {
+      // Success: keep the spinner up; PublicRoute redirects to "/" once the
+      // session resolves and AuthContext loads the profile.
+    } catch (error) {
       // Single generic message — never reveal whether the account exists.
       console.error(error);
       setErrorMsg('Invalid email/username or password.');
-    }
-    finally {
-      setIsLoading(false)
+      setIsLoading(false);
     }
   };
 
-  // While we are checking if a session exists (on load), show a simple spinner.
-  if (isAuthChecking) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-950">
-        <div className="w-16 h-16 border-4 border-emerald-500 border-t-transparent rounded-full animate-spin"></div>
-      </div>
-    );
-  }
-
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-950 px-4">
+    <div className="min-h-dvh flex items-center justify-center bg-gray-50 dark:bg-gray-950 px-4">
       <div className="max-w-md w-full space-y-8 bg-white dark:bg-gray-900 p-8 rounded-2xl shadow-xl border border-gray-100 dark:border-gray-800">
 
         <div className="text-center">
@@ -95,6 +66,8 @@ export function LoginPage() {
                 required
                 value={loginInput}
                 onChange={(e) => setLoginInput(e.target.value)}
+                autoCapitalize="none"
+                autoCorrect="off"
                 className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm focus:outline-none focus:ring-emerald-500 focus:border-emerald-500 dark:bg-gray-800 dark:text-gray-100 sm:text-sm"
                 placeholder="Username"
               />

--- a/src/shared/components/ErrorBoundary.tsx
+++ b/src/shared/components/ErrorBoundary.tsx
@@ -1,0 +1,59 @@
+import { Component, type ReactNode, type ErrorInfo } from 'react';
+
+/**
+ * --- ERROR BOUNDARY ---
+ * Catches render-time exceptions anywhere below it (e.g. an unexpected shape that
+ * makes a Zod parse throw) and shows a recoverable fallback instead of a blank
+ * white screen. Without this, any thrown error unmounts the entire app.
+ */
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Surface for debugging / future error-reporting integration.
+    console.error('Unhandled UI error:', error, info.componentStack);
+  }
+
+  private handleReload = () => {
+    window.location.assign('/');
+  };
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    return (
+      <div className="min-h-dvh flex items-center justify-center bg-white dark:bg-gray-950 p-6">
+        <div className="text-center space-y-4 max-w-sm">
+          <div className="mx-auto w-14 h-14 rounded-2xl bg-red-50 dark:bg-red-900/20 text-red-500 flex items-center justify-center text-2xl font-black">
+            !
+          </div>
+          <div className="space-y-1">
+            <h1 className="text-xl font-black text-gray-900 dark:text-white">Something went wrong</h1>
+            <p className="text-sm text-gray-500">
+              An unexpected error occurred. Reloading usually fixes it.
+            </p>
+          </div>
+          <button
+            onClick={this.handleReload}
+            className="px-5 py-2.5 rounded-xl font-bold text-sm text-white bg-emerald-500 hover:bg-emerald-600 transition-colors shadow-lg shadow-emerald-500/25"
+          >
+            Reload app
+          </button>
+        </div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
Phase 2, part 1.

**A1 — declarative auth routing.** AuthContext no longer navigates; it's reactive state synced via `onAuthStateChange` (login/logout/token-refresh/invite-verify), flipping `isAuthChecking` only after the initial profile load. New `ProtectedRoute`/`PublicRoute` gate the shell and login; `/accept-invite` stays unguarded. LoginPage is now a pure form (guards handle redirects). Removes the AuthContext↔LoginPage↔guard redirect races and pre-redirect content flashing.

**A2 — error boundary.** Wraps the app; a render/parse throw shows a recoverable 'Reload app' fallback instead of a white screen.

Verified tsc/eslint/build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)