### PR TITLE
refactor(phase2): React Query data layer (A3) + AdminPage decomposition (A4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@formkit/auto-animate": "^0.9.0",
         "@phosphor-icons/react": "^2.1.10",
         "@supabase/supabase-js": "^2.97.0",
+        "@tanstack/react-query": "^5.101.0",
         "framer-motion": "^12.34.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -3531,6 +3532,32 @@
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@total-typescript/ts-reset": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@formkit/auto-animate": "^0.9.0",
     "@phosphor-icons/react": "^2.1.10",
     "@supabase/supabase-js": "^2.97.0",
+    "@tanstack/react-query": "^5.101.0",
     "framer-motion": "^12.34.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,18 @@
 import { lazy, Suspense } from 'react';
 import { Route, Routes, Navigate } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // Providers (Global State)
 import { AuthProvider } from './features/auth/AuthContext';
 import { ShiftProvider } from './features/shifts/ShiftContext';
 import { ThemeProvider } from './app/providers/ThemeContext';
+
+// Single shared React Query client (caching, dedupe, retries for server state).
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { staleTime: 30_000, retry: 1, refetchOnWindowFocus: false },
+  },
+});
 
 // App Shell (eager — it is the persistent frame around every page).
 import { AppShell } from './app/layout/AppShell';
@@ -38,7 +46,8 @@ const SettingsPage = lazy(() => import('./features/settings/SettingsPage'));
 export default function App() {
   return (
     <ErrorBoundary>
-      <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+       <ThemeProvider>
         <AuthProvider>
           <ShiftProvider>
             <Suspense fallback={<PageLoader />}>
@@ -70,7 +79,8 @@ export default function App() {
             </Suspense>
           </ShiftProvider>
         </AuthProvider>
-      </ThemeProvider>
+       </ThemeProvider>
+      </QueryClientProvider>
     </ErrorBoundary>
   );
 }

--- a/src/features/admin/AdminContext.tsx
+++ b/src/features/admin/AdminContext.tsx
@@ -1,20 +1,17 @@
-import {
-    createContext,
-    useContext,
-    useState,
-    useEffect,
-    useCallback,
-    type ReactNode,
-} from 'react';
+import { createContext, useContext, useCallback, type ReactNode } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { adminService, type EmployeeUpdate, type EmployeeInvite } from './adminService';
 import { useAuthContext } from '@/features/auth/AuthContext';
 import type { Organization, Role } from '@/shared/types';
 
 /**
  * --- ADMIN CONTEXT ---
- * Holds the full organization tree + roles for the Admin Panel and exposes
- * every CRUD action. Mutations run against Supabase and then re-fetch the tree
- * so the UI always reflects the database (no drifting optimistic state).
+ * Backed by React Query: the org tree + roles are cached server state (useQuery),
+ * and every mutation invalidates the tree so the UI re-syncs. This removes the
+ * hand-rolled "fetch-all + manual refreshData + isLoading/error" plumbing the
+ * context used to carry, and gives caching, dedupe and retries for free.
+ *
+ * The public API is unchanged, so the panel/forms below don't need to change.
  */
 
 interface AdminContextType {
@@ -43,121 +40,114 @@ interface AdminContextType {
 
 const AdminContext = createContext<AdminContextType | undefined>(undefined);
 
+const TREE_KEY = ['admin', 'tree'] as const;
+const ROLES_KEY = ['admin', 'roles'] as const;
+
 export function AdminProvider({ children }: { children: ReactNode }) {
     const { user } = useAuthContext();
     const isSuperAdmin = user?.role.name === 'Superadmin';
+    const queryClient = useQueryClient();
 
-    const [adminData, setAdminData] = useState<Organization[] | null>(null);
-    const [roles, setRoles] = useState<Role[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
+    const treeQuery = useQuery({
+        queryKey: [...TREE_KEY, user?.id],
+        queryFn: () => adminService.getAdminData(isSuperAdmin, user!),
+        enabled: !!user,
+    });
 
-    const refreshData = useCallback(async () => {
-        if (!user) return;
-        try {
-            setError(null);
-            const data = await adminService.getAdminData(isSuperAdmin, user);
-            setAdminData(data);
-        } catch (err) {
-            console.error('Failed to load admin data:', err);
-            setError(err instanceof Error ? err.message : 'Failed to load admin data.');
-        } finally {
-            setIsLoading(false);
-        }
-    }, [isSuperAdmin, user]);
+    const rolesQuery = useQuery({
+        queryKey: ROLES_KEY,
+        queryFn: () => adminService.getRoles(),
+        enabled: !!user,
+        staleTime: 5 * 60 * 1000, // roles rarely change
+    });
 
-    useEffect(() => {
-        if (!user) return;
-        refreshData();
-        adminService.getRoles().then(setRoles).catch((err) => console.error('Failed to load roles:', err));
-    }, [user, refreshData]);
+    const invalidateTree = useCallback(
+        () => queryClient.invalidateQueries({ queryKey: TREE_KEY }),
+        [queryClient],
+    );
+
+    // A mutation that runs a service call then re-syncs the tree. We keep the
+    // imperative async signatures the existing forms already call/await.
+    const mutation = useMutation({
+        mutationFn: (action: () => Promise<void>) => action(),
+        onSuccess: invalidateTree,
+    });
+    const run = useCallback((action: () => Promise<void>) => mutation.mutateAsync(action), [mutation]);
 
     // Organizations -------------------------------------------------
     const createOrganization = useCallback(
-        async (name: string, slug: string) => {
-            if (!isSuperAdmin) throw new Error('Only a Superadmin can manage organizations.');
-            await adminService.createOrganization(name, slug);
-            await refreshData();
-        },
-        [isSuperAdmin, refreshData],
+        (name: string, slug: string) =>
+            run(async () => {
+                if (!isSuperAdmin) throw new Error('Only a Superadmin can manage organizations.');
+                await adminService.createOrganization(name, slug);
+            }),
+        [isSuperAdmin, run],
     );
 
     const updateOrganization = useCallback(
-        async (id: string, values: { name: string; slug: string }) => {
-            if (!isSuperAdmin) throw new Error('Only a Superadmin can manage organizations.');
-            await adminService.updateOrganization(id, values);
-            await refreshData();
-        },
-        [isSuperAdmin, refreshData],
+        (id: string, values: { name: string; slug: string }) =>
+            run(async () => {
+                if (!isSuperAdmin) throw new Error('Only a Superadmin can manage organizations.');
+                await adminService.updateOrganization(id, values);
+            }),
+        [isSuperAdmin, run],
     );
 
     const deleteOrganization = useCallback(
-        async (id: string) => {
-            if (!isSuperAdmin) throw new Error('Only a Superadmin can manage organizations.');
-            await adminService.deleteOrganization(id);
-            await refreshData();
-        },
-        [isSuperAdmin, refreshData],
+        (id: string) =>
+            run(async () => {
+                if (!isSuperAdmin) throw new Error('Only a Superadmin can manage organizations.');
+                await adminService.deleteOrganization(id);
+            }),
+        [isSuperAdmin, run],
     );
 
     // Locations -----------------------------------------------------
     const createLocation = useCallback(
-        async (values: { organization_id: string; name: string }) => {
-            await adminService.createLocation(values);
-            await refreshData();
-        },
-        [refreshData],
+        (values: { organization_id: string; name: string }) =>
+            run(() => adminService.createLocation(values)),
+        [run],
     );
-
     const updateLocation = useCallback(
-        async (id: string, name: string) => {
-            await adminService.updateLocation(id, name);
-            await refreshData();
-        },
-        [refreshData],
+        (id: string, name: string) => run(() => adminService.updateLocation(id, name)),
+        [run],
     );
-
     const deleteLocation = useCallback(
-        async (id: string) => {
-            await adminService.deleteLocation(id);
-            await refreshData();
-        },
-        [refreshData],
+        (id: string) => run(() => adminService.deleteLocation(id)),
+        [run],
     );
 
     // Employees -----------------------------------------------------
     const inviteEmployee = useCallback(
-        async (payload: EmployeeInvite) => {
-            await adminService.inviteEmployee(payload);
-            await refreshData();
-        },
-        [refreshData],
+        (payload: EmployeeInvite) => run(() => adminService.inviteEmployee(payload)),
+        [run],
     );
-
     const updateEmployee = useCallback(
-        async (id: string, values: EmployeeUpdate) => {
-            await adminService.updateEmployee(id, values);
-            await refreshData();
-        },
-        [refreshData],
+        (id: string, values: EmployeeUpdate) => run(() => adminService.updateEmployee(id, values)),
+        [run],
     );
-
     const deleteEmployee = useCallback(
-        async (id: string) => {
-            if (id === user?.id) throw new Error('You cannot delete your own account.');
-            await adminService.deleteEmployee(id);
-            await refreshData();
-        },
-        [user?.id, refreshData],
+        (id: string) =>
+            run(async () => {
+                if (id === user?.id) throw new Error('You cannot delete your own account.');
+                await adminService.deleteEmployee(id);
+            }),
+        [user?.id, run],
     );
 
     const value: AdminContextType = {
-        adminData,
-        roles,
-        isLoading,
-        error,
+        adminData: treeQuery.data ?? null,
+        roles: rolesQuery.data ?? [],
+        isLoading: treeQuery.isLoading,
+        error: treeQuery.error
+            ? treeQuery.error instanceof Error
+                ? treeQuery.error.message
+                : 'Failed to load admin data.'
+            : null,
         isSuperAdmin,
-        refreshData,
+        refreshData: async () => {
+            await invalidateTree();
+        },
         createOrganization,
         updateOrganization,
         deleteOrganization,

--- a/src/features/admin/AdminPage.tsx
+++ b/src/features/admin/AdminPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
     BuildingsIcon,
@@ -6,32 +6,24 @@ import {
     UsersIcon,
     PlusIcon,
     PaperPlaneTiltIcon,
-    PencilSimpleIcon,
-    TrashIcon,
     MagnifyingGlassIcon,
-    type Icon,
 } from '@phosphor-icons/react';
-import type { Organization, Profile, User } from '@/shared/types';
-import { getRoleBadgeColor } from '@/shared/utils/roleColors';
-import { getFullInitials } from '@/shared/utils/getInitials';
+import type { Organization, Profile } from '@/shared/types';
 
 import { useAuthContext } from '@/features/auth/AuthContext';
 import { AdminProvider, useAdminContext } from './AdminContext';
-import { canManageEmployees, canManageLocations, canManageMember, RANK } from './permissions';
+import { canManageEmployees, canManageLocations } from './permissions';
 import { ConfirmDialog } from './components/Modal';
 import { OrganizationForm } from './components/OrganizationForm';
 import { LocationForm, type LocationEditTarget } from './components/LocationForm';
 import { EmployeeForm } from './components/EmployeeForm';
 import { InviteEmployeeForm } from './components/InviteEmployeeForm';
+import { StatCard, ErrorState } from './components/AdminStateViews';
+import { OrganizationsList } from './components/OrganizationsList';
+import { LocationsList, type LocationRow } from './components/LocationsList';
+import { EmployeesList } from './components/EmployeesList';
 
 type TabType = 'employees' | 'locations' | 'organizations';
-
-interface LocationRow {
-    id: string;
-    name: string;
-    organization_id: string;
-    organizationName: string;
-}
 
 type ModalState =
     | { kind: 'org-form'; org?: Organization }
@@ -49,7 +41,8 @@ const ADD_LABEL: Record<TabType, string> = {
 
 /**
  * --- ADMIN PAGE ---
- * Entry point: provides admin state to the panel below it.
+ * Entry point: provides admin state to the panel below it. The presentational
+ * pieces (lists, stat cards, state views, action buttons) live in ./components.
  */
 export function AdminPage() {
     return (
@@ -295,278 +288,6 @@ function AdminPanel() {
                     />
                 )}
             </AnimatePresence>
-        </div>
-    );
-}
-
-// ==========================================
-// STATE HELPERS
-// ==========================================
-
-const STAT_ACCENTS: Record<string, string> = {
-    emerald: 'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 dark:text-emerald-400',
-    blue: 'bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400',
-    violet: 'bg-violet-50 dark:bg-violet-900/20 text-violet-600 dark:text-violet-400',
-};
-
-function StatCard({ icon: StatIcon, label, value, accent }: { icon: Icon; label: string; value: number; accent: string }) {
-    return (
-        <div className="flex items-center gap-3 p-3 sm:p-4 bg-white dark:bg-gray-800/30 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm">
-            <div className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 ${STAT_ACCENTS[accent]}`}>
-                <StatIcon className="w-5 h-5" weight="bold" />
-            </div>
-            <div className="min-w-0">
-                <p className="text-xl sm:text-2xl font-black text-gray-900 dark:text-white leading-none">{value}</p>
-                <p className="text-[9px] sm:text-[10px] font-bold text-gray-400 uppercase tracking-widest mt-1">{label}</p>
-            </div>
-        </div>
-    );
-}
-
-function LoadingState({ label }: { label: string }) {
-    return (
-        <div className="py-20 text-center text-gray-400 text-xs font-bold uppercase tracking-widest animate-pulse">
-            Loading {label}…
-        </div>
-    );
-}
-
-function EmptyState({ label }: { label: string }) {
-    return (
-        <div className="py-20 text-center text-gray-400 text-xs font-bold uppercase tracking-widest">No {label} found</div>
-    );
-}
-
-function ErrorState({ message }: { message: string }) {
-    return (
-        <div className="py-16 text-center space-y-1">
-            <p className="text-red-500 text-xs font-black uppercase tracking-widest">Something went wrong</p>
-            <p className="text-gray-400 text-xs font-medium">{message}</p>
-        </div>
-    );
-}
-
-// ==========================================
-// SUB-COMPONENTS
-// ==========================================
-
-function AdminBadgeWithTooltip() {
-    const [isVisible, setIsVisible] = useState(false);
-
-    useEffect(() => {
-        if (isVisible) {
-            const timer = setTimeout(() => setIsVisible(false), 2000);
-            return () => clearTimeout(timer);
-        }
-    }, [isVisible]);
-
-    return (
-        <div className="relative flex items-center shrink-0">
-            <button
-                onMouseEnter={() => setIsVisible(true)}
-                onMouseLeave={() => setIsVisible(false)}
-                onClick={(e) => {
-                    e.stopPropagation();
-                    setIsVisible(!isVisible);
-                }}
-                className="shrink-0 w-3.5 h-3.5 sm:w-4 sm:h-4 rounded bg-amber-400/10 border border-amber-500/20 flex items-center justify-center cursor-help transition-colors hover:bg-amber-500/20"
-            >
-                <span className="text-[8px] sm:text-[10px] font-black text-amber-600 dark:text-amber-400 leading-none">A</span>
-            </button>
-
-            <AnimatePresence>
-                {isVisible && (
-                    <motion.div
-                        initial={{ opacity: 0, scale: 0.8, y: 5 }}
-                        animate={{ opacity: 1, scale: 1, y: -2 }}
-                        exit={{ opacity: 0, scale: 0.8, y: 5 }}
-                        className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 bg-gray-900 dark:bg-white text-white dark:text-gray-900 text-[8px] font-black uppercase tracking-widest rounded-md shadow-xl z-50 whitespace-nowrap pointer-events-none"
-                    >
-                        Administrator
-                        <div className="absolute top-full left-1/2 -translate-x-1/2 border-[4px] border-transparent border-t-gray-900 dark:border-t-white" />
-                    </motion.div>
-                )}
-            </AnimatePresence>
-        </div>
-    );
-}
-
-function OrganizationsList({
-    items,
-    isLoading,
-    onEdit,
-    onDelete,
-}: {
-    items: Organization[];
-    isLoading: boolean;
-    onEdit: (org: Organization) => void;
-    onDelete: (org: Organization) => void;
-}) {
-    if (isLoading) return <LoadingState label="organizations" />;
-    if (items.length === 0) return <EmptyState label="organizations" />;
-
-    return (
-        <div className="grid gap-2">
-            {items.map((org) => (
-                <div
-                    key={org.id}
-                    className="flex items-center gap-3 p-2 bg-white dark:bg-gray-800/30 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm"
-                >
-                    <div className="w-10 h-10 rounded-xl bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 flex items-center justify-center shrink-0">
-                        <BuildingsIcon className="w-5 h-5" weight="bold" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                        <h3 className="font-bold text-sm dark:text-white truncate">{org.name}</h3>
-                        <p className="text-[10px] text-gray-400 font-bold uppercase tracking-tight">{org.slug}</p>
-                    </div>
-                    <div className="flex items-center gap-6 pr-2">
-                        <div className="hidden sm:flex gap-4">
-                            <div className="text-center">
-                                <p className="text-xs font-black dark:text-white">{org.locations.length}</p>
-                                <p className="text-[8px] font-bold text-gray-400 uppercase tracking-tighter">Locs</p>
-                            </div>
-                            <div className="text-center">
-                                <p className="text-xs font-black dark:text-white">{org.profiles.length}</p>
-                                <p className="text-[8px] font-bold text-gray-400 uppercase tracking-tighter">Users</p>
-                            </div>
-                        </div>
-                        <ActionButtons onEdit={() => onEdit(org)} onDelete={() => onDelete(org)} />
-                    </div>
-                </div>
-            ))}
-        </div>
-    );
-}
-
-function LocationsList({
-    items,
-    isLoading,
-    canManage,
-    onEdit,
-    onDelete,
-}: {
-    items: LocationRow[];
-    isLoading: boolean;
-    canManage: boolean;
-    onEdit: (loc: LocationRow) => void;
-    onDelete: (loc: LocationRow) => void;
-}) {
-    if (isLoading) return <LoadingState label="locations" />;
-    if (items.length === 0) return <EmptyState label="locations" />;
-
-    return (
-        <div className="grid gap-2">
-            {items.map((loc) => (
-                <div
-                    key={loc.id}
-                    className="flex items-center gap-3 p-2 bg-white dark:bg-gray-800/30 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm"
-                >
-                    <div className="w-10 h-10 rounded-xl bg-blue-50 dark:bg-blue-900/20 text-blue-600 flex items-center justify-center shrink-0">
-                        <MapPinIcon className="w-5 h-5" weight="bold" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                        <h3 className="font-bold text-sm dark:text-white truncate">{loc.name}</h3>
-                        <p className="text-[10px] text-gray-400 font-bold uppercase tracking-tight">{loc.organizationName}</p>
-                    </div>
-                    <div className="flex items-center gap-4 pr-2">
-                        <span className="hidden sm:inline-block px-2 py-1 bg-gray-100 dark:bg-gray-800 text-gray-500 text-[8px] font-black rounded uppercase tracking-widest">
-                            {loc.id.slice(0, 8)}
-                        </span>
-                        {canManage && <ActionButtons onEdit={() => onEdit(loc)} onDelete={() => onDelete(loc)} />}
-                    </div>
-                </div>
-            ))}
-        </div>
-    );
-}
-
-function EmployeesList({
-    items,
-    isLoading,
-    currentUser,
-    onEdit,
-    onDelete,
-}: {
-    items: Profile[];
-    isLoading: boolean;
-    currentUser: User | null;
-    onEdit: (emp: Profile) => void;
-    onDelete: (emp: Profile) => void;
-}) {
-    if (isLoading) return <LoadingState label="employees" />;
-    if (items.length === 0) return <EmptyState label="employees" />;
-
-    return (
-        <div className="grid gap-2">
-            {items.map((employee) => {
-                const isSelf = employee.id === currentUser?.id;
-                const manageable = currentUser ? canManageMember(currentUser, employee) : false;
-                return (
-                    <div
-                        key={employee.id}
-                        className="flex items-center gap-2 sm:gap-3 p-1.5 sm:p-2 bg-white dark:bg-gray-800/30 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm"
-                    >
-                        <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-full bg-emerald-100 dark:bg-emerald-900/40 border-2 border-white dark:border-white/10 flex items-center justify-center text-emerald-700 dark:text-emerald-400 text-[10px] font-black shrink-0">
-                            {getFullInitials(employee.first_name, employee.last_name)}
-                        </div>
-                        <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-1.5">
-                                <h3 className="font-bold text-xs sm:text-sm dark:text-white truncate leading-tight">
-                                    {employee.first_name} {employee.last_name}
-                                </h3>
-                                {employee.role.rank >= RANK.ADMIN && <AdminBadgeWithTooltip />}
-                                {isSelf && (
-                                    <span className="shrink-0 px-1.5 py-0.5 text-[7px] sm:text-[8px] font-black rounded uppercase tracking-widest bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400">
-                                        You
-                                    </span>
-                                )}
-                            </div>
-                            <p className="text-[9px] sm:text-[10px] text-emerald-600 dark:text-emerald-400 font-bold truncate leading-tight">
-                                @{employee.username}
-                            </p>
-                            <p className="text-[9px] sm:text-[10px] text-gray-400 font-bold uppercase tracking-tight truncate">
-                                {employee.email}
-                            </p>
-                        </div>
-                        <div className="flex items-center gap-2 sm:gap-4 shrink-0">
-                            <span
-                                className={`px-1.5 py-0.5 sm:px-2 sm:py-1 text-[7px] sm:text-[8px] font-black rounded-md uppercase tracking-widest ${getRoleBadgeColor(
-                                    employee.role.name,
-                                )}`}
-                            >
-                                {employee.role.name}
-                            </span>
-                            {/* Only members ranked below you can be edited or removed (never yourself). */}
-                            {manageable && (
-                                <ActionButtons onEdit={() => onEdit(employee)} onDelete={() => onDelete(employee)} />
-                            )}
-                        </div>
-                    </div>
-                );
-            })}
-        </div>
-    );
-}
-
-function ActionButtons({ onEdit, onDelete }: { onEdit: () => void; onDelete?: () => void }) {
-    return (
-        <div className="flex items-center gap-0.5">
-            <button
-                onClick={onEdit}
-                className="p-1.5 sm:p-2 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:hover:bg-emerald-500/10 rounded-lg transition-colors"
-                aria-label="Edit"
-            >
-                <PencilSimpleIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" weight="bold" />
-            </button>
-            {onDelete && (
-                <button
-                    onClick={onDelete}
-                    className="p-1.5 sm:p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-500/10 rounded-lg transition-colors"
-                    aria-label="Delete"
-                >
-                    <TrashIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" weight="bold" />
-                </button>
-            )}
         </div>
     );
 }

--- a/src/features/admin/components/ActionButtons.tsx
+++ b/src/features/admin/components/ActionButtons.tsx
@@ -1,0 +1,25 @@
+import { PencilSimpleIcon, TrashIcon } from '@phosphor-icons/react';
+
+/** Edit / delete icon buttons shared by every admin list row. */
+export function ActionButtons({ onEdit, onDelete }: { onEdit: () => void; onDelete?: () => void }) {
+    return (
+        <div className="flex items-center gap-0.5">
+            <button
+                onClick={onEdit}
+                className="p-1.5 sm:p-2 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:hover:bg-emerald-500/10 rounded-lg transition-colors"
+                aria-label="Edit"
+            >
+                <PencilSimpleIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" weight="bold" />
+            </button>
+            {onDelete && (
+                <button
+                    onClick={onDelete}
+                    className="p-1.5 sm:p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-500/10 rounded-lg transition-colors"
+                    aria-label="Delete"
+                >
+                    <TrashIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" weight="bold" />
+                </button>
+            )}
+        </div>
+    );
+}

--- a/src/features/admin/components/AdminStateViews.tsx
+++ b/src/features/admin/components/AdminStateViews.tsx
@@ -1,0 +1,56 @@
+import type { Icon } from '@phosphor-icons/react';
+
+/** Small presentational helpers shared across the admin panel. */
+
+const STAT_ACCENTS: Record<string, string> = {
+    emerald: 'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 dark:text-emerald-400',
+    blue: 'bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400',
+    violet: 'bg-violet-50 dark:bg-violet-900/20 text-violet-600 dark:text-violet-400',
+};
+
+export function StatCard({
+    icon: StatIcon,
+    label,
+    value,
+    accent,
+}: {
+    icon: Icon;
+    label: string;
+    value: number;
+    accent: string;
+}) {
+    return (
+        <div className="flex items-center gap-3 p-3 sm:p-4 bg-white dark:bg-gray-800/30 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm">
+            <div className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 ${STAT_ACCENTS[accent]}`}>
+                <StatIcon className="w-5 h-5" weight="bold" />
+            </div>
+            <div className="min-w-0">
+                <p className="text-xl sm:text-2xl font-black text-gray-900 dark:text-white leading-none">{value}</p>
+                <p className="text-[9px] sm:text-[10px] font-bold text-gray-400 uppercase tracking-widest mt-1">{label}</p>
+            </div>
+        </div>
+    );
+}
+
+export function LoadingState({ label }: { label: string }) {
+    return (
+        <div className="py-20 text-center text-gray-400 text-xs font-bold uppercase tracking-widest animate-pulse">
+            Loading {label}…
+        </div>
+    );
+}
+
+export function EmptyState({ label }: { label: string }) {
+    return (
+        <div className="py-20 text-center text-gray-400 text-xs font-bold uppercase tracking-widest">No {label} found</div>
+    );
+}
+
+export function ErrorState({ message }: { message: string }) {
+    return (
+        <div className="py-16 text-center space-y-1">
+            <p className="text-red-500 text-xs font-black uppercase tracking-widest">Something went wrong</p>
+            <p className="text-gray-400 text-xs font-medium">{message}</p>
+        </div>
+    );
+}

--- a/src/features/admin/components/EmployeesList.tsx
+++ b/src/features/admin/components/EmployeesList.tsx
@@ -1,0 +1,118 @@
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import type { Profile, User } from '@/shared/types';
+import { getRoleBadgeColor } from '@/shared/utils/roleColors';
+import { getFullInitials } from '@/shared/utils/getInitials';
+import { canManageMember, RANK } from '../permissions';
+import { ActionButtons } from './ActionButtons';
+import { LoadingState, EmptyState } from './AdminStateViews';
+
+/** Small "A" badge with a tap/hover "Administrator" tooltip. */
+function AdminBadgeWithTooltip() {
+    const [isVisible, setIsVisible] = useState(false);
+
+    useEffect(() => {
+        if (isVisible) {
+            const timer = setTimeout(() => setIsVisible(false), 2000);
+            return () => clearTimeout(timer);
+        }
+    }, [isVisible]);
+
+    return (
+        <div className="relative flex items-center shrink-0">
+            <button
+                onMouseEnter={() => setIsVisible(true)}
+                onMouseLeave={() => setIsVisible(false)}
+                onClick={(e) => {
+                    e.stopPropagation();
+                    setIsVisible(!isVisible);
+                }}
+                className="shrink-0 w-3.5 h-3.5 sm:w-4 sm:h-4 rounded bg-amber-400/10 border border-amber-500/20 flex items-center justify-center cursor-help transition-colors hover:bg-amber-500/20"
+            >
+                <span className="text-[8px] sm:text-[10px] font-black text-amber-600 dark:text-amber-400 leading-none">A</span>
+            </button>
+
+            <AnimatePresence>
+                {isVisible && (
+                    <motion.div
+                        initial={{ opacity: 0, scale: 0.8, y: 5 }}
+                        animate={{ opacity: 1, scale: 1, y: -2 }}
+                        exit={{ opacity: 0, scale: 0.8, y: 5 }}
+                        className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 bg-gray-900 dark:bg-white text-white dark:text-gray-900 text-[8px] font-black uppercase tracking-widest rounded-md shadow-xl z-50 whitespace-nowrap pointer-events-none"
+                    >
+                        Administrator
+                        <div className="absolute top-full left-1/2 -translate-x-1/2 border-[4px] border-transparent border-t-gray-900 dark:border-t-white" />
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+}
+
+export function EmployeesList({
+    items,
+    isLoading,
+    currentUser,
+    onEdit,
+    onDelete,
+}: {
+    items: Profile[];
+    isLoading: boolean;
+    currentUser: User | null;
+    onEdit: (emp: Profile) => void;
+    onDelete: (emp: Profile) => void;
+}) {
+    if (isLoading) return <LoadingState label="employees" />;
+    if (items.length === 0) return <EmptyState label="employees" />;
+
+    return (
+        <div className="grid gap-2">
+            {items.map((employee) => {
+                const isSelf = employee.id === currentUser?.id;
+                const manageable = currentUser ? canManageMember(currentUser, employee) : false;
+                return (
+                    <div
+                        key={employee.id}
+                        className="flex items-center gap-2 sm:gap-3 p-1.5 sm:p-2 bg-white dark:bg-gray-800/30 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm"
+                    >
+                        <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-full bg-emerald-100 dark:bg-emerald-900/40 border-2 border-white dark:border-white/10 flex items-center justify-center text-emerald-700 dark:text-emerald-400 text-[10px] font-black shrink-0">
+                            {getFullInitials(employee.first_name, employee.last_name)}
+                        </div>
+                        <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-1.5">
+                                <h3 className="font-bold text-xs sm:text-sm dark:text-white truncate leading-tight">
+                                    {employee.first_name} {employee.last_name}
+                                </h3>
+                                {employee.role.rank >= RANK.ADMIN && <AdminBadgeWithTooltip />}
+                                {isSelf && (
+                                    <span className="shrink-0 px-1.5 py-0.5 text-[7px] sm:text-[8px] font-black rounded uppercase tracking-widest bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400">
+                                        You
+                                    </span>
+                                )}
+                            </div>
+                            <p className="text-[9px] sm:text-[10px] text-emerald-600 dark:text-emerald-400 font-bold truncate leading-tight">
+                                @{employee.username}
+                            </p>
+                            <p className="text-[9px] sm:text-[10px] text-gray-400 font-bold uppercase tracking-tight truncate">
+                                {employee.email}
+                            </p>
+                        </div>
+                        <div className="flex items-center gap-2 sm:gap-4 shrink-0">
+                            <span
+                                className={`px-1.5 py-0.5 sm:px-2 sm:py-1 text-[7px] sm:text-[8px] font-black rounded-md uppercase tracking-widest ${getRoleBadgeColor(
+                                    employee.role.name,
+                                )}`}
+                            >
+                                {employee.role.name}
+                            </span>
+                            {/* Only members ranked below you can be edited or removed (never yourself). */}
+                            {manageable && (
+                                <ActionButtons onEdit={() => onEdit(employee)} onDelete={() => onDelete(employee)} />
+                            )}
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/features/admin/components/LocationsList.tsx
+++ b/src/features/admin/components/LocationsList.tsx
@@ -1,0 +1,52 @@
+import { MapPinIcon } from '@phosphor-icons/react';
+import { ActionButtons } from './ActionButtons';
+import { LoadingState, EmptyState } from './AdminStateViews';
+
+export interface LocationRow {
+    id: string;
+    name: string;
+    organization_id: string;
+    organizationName: string;
+}
+
+export function LocationsList({
+    items,
+    isLoading,
+    canManage,
+    onEdit,
+    onDelete,
+}: {
+    items: LocationRow[];
+    isLoading: boolean;
+    canManage: boolean;
+    onEdit: (loc: LocationRow) => void;
+    onDelete: (loc: LocationRow) => void;
+}) {
+    if (isLoading) return <LoadingState label="locations" />;
+    if (items.length === 0) return <EmptyState label="locations" />;
+
+    return (
+        <div className="grid gap-2">
+            {items.map((loc) => (
+                <div
+                    key={loc.id}
+                    className="flex items-center gap-3 p-2 bg-white dark:bg-gray-800/30 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm"
+                >
+                    <div className="w-10 h-10 rounded-xl bg-blue-50 dark:bg-blue-900/20 text-blue-600 flex items-center justify-center shrink-0">
+                        <MapPinIcon className="w-5 h-5" weight="bold" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                        <h3 className="font-bold text-sm dark:text-white truncate">{loc.name}</h3>
+                        <p className="text-[10px] text-gray-400 font-bold uppercase tracking-tight">{loc.organizationName}</p>
+                    </div>
+                    <div className="flex items-center gap-4 pr-2">
+                        <span className="hidden sm:inline-block px-2 py-1 bg-gray-100 dark:bg-gray-800 text-gray-500 text-[8px] font-black rounded uppercase tracking-widest">
+                            {loc.id.slice(0, 8)}
+                        </span>
+                        {canManage && <ActionButtons onEdit={() => onEdit(loc)} onDelete={() => onDelete(loc)} />}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/features/admin/components/OrganizationsList.tsx
+++ b/src/features/admin/components/OrganizationsList.tsx
@@ -1,0 +1,51 @@
+import { BuildingsIcon } from '@phosphor-icons/react';
+import type { Organization } from '@/shared/types';
+import { ActionButtons } from './ActionButtons';
+import { LoadingState, EmptyState } from './AdminStateViews';
+
+export function OrganizationsList({
+    items,
+    isLoading,
+    onEdit,
+    onDelete,
+}: {
+    items: Organization[];
+    isLoading: boolean;
+    onEdit: (org: Organization) => void;
+    onDelete: (org: Organization) => void;
+}) {
+    if (isLoading) return <LoadingState label="organizations" />;
+    if (items.length === 0) return <EmptyState label="organizations" />;
+
+    return (
+        <div className="grid gap-2">
+            {items.map((org) => (
+                <div
+                    key={org.id}
+                    className="flex items-center gap-3 p-2 bg-white dark:bg-gray-800/30 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm"
+                >
+                    <div className="w-10 h-10 rounded-xl bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 flex items-center justify-center shrink-0">
+                        <BuildingsIcon className="w-5 h-5" weight="bold" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                        <h3 className="font-bold text-sm dark:text-white truncate">{org.name}</h3>
+                        <p className="text-[10px] text-gray-400 font-bold uppercase tracking-tight">{org.slug}</p>
+                    </div>
+                    <div className="flex items-center gap-6 pr-2">
+                        <div className="hidden sm:flex gap-4">
+                            <div className="text-center">
+                                <p className="text-xs font-black dark:text-white">{org.locations.length}</p>
+                                <p className="text-[8px] font-bold text-gray-400 uppercase tracking-tighter">Locs</p>
+                            </div>
+                            <div className="text-center">
+                                <p className="text-xs font-black dark:text-white">{org.profiles.length}</p>
+                                <p className="text-[8px] font-bold text-gray-400 uppercase tracking-tighter">Users</p>
+                            </div>
+                        </div>
+                        <ActionButtons onEdit={() => onEdit(org)} onDelete={() => onDelete(org)} />
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}


### PR DESCRIPTION
Finishes Phase 2 of the audit refactor.

**A3 — React Query for AdminContext.** Replaces the hand-rolled fetch-all + manual `refreshData`/`isLoading`/`error` plumbing with `useQuery` (org tree + roles) and mutation-driven invalidation — caching, dedupe, retries for free. Public context API unchanged (panel/forms untouched). Shifts intentionally stay on their realtime hook (Query is a poor fit for a push dataset). Adds `@tanstack/react-query` + `QueryClientProvider`.

**A4 — AdminPage decomposition.** Extracts the inlined sub-components from the ~570-line file into `./components` (ActionButtons, AdminStateViews, OrganizationsList, LocationsList, EmployeesList). AdminPage is now ~290 lines of orchestration. No behaviour change.

Verified tsc/eslint/build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)