### PR TITLE
feat(mobile): native-grade mobile UX pass (Phase 3)

### DIFF
--- a/src/app/layout/AppShell.tsx
+++ b/src/app/layout/AppShell.tsx
@@ -8,6 +8,7 @@ import { useShiftContext } from '@features/shifts/ShiftContext';
 import { useLocationManagement } from '@features/locations/hooks/useLocationManagement';
 
 import { Dashboard } from '@features/dashboard/Dashboard';
+import { BottomNav } from './BottomNav';
 import { LocationPopup } from '@features/locations/components/LocationPopup';
 import { type User, type Shift, type Location } from '@shared/types';
 
@@ -70,14 +71,18 @@ export function AppShell() {
   };
 
   return (
-    <div className="App min-h-screen w-full font-sans md:flex md:flex-row transition-all duration-500 ease-in-out">
+    <div className="App min-h-dvh w-full font-sans md:flex md:flex-row transition-all duration-500 ease-in-out">
       {/* SIDEBAR NAVIGATION */}
       <Dashboard onLocationSelect={handleLocationSelect} />
 
-      {/* MAIN CONTENT AREA */}
-      <main className="flex-1 p-3 pb-40 md:p-6 md:pb-6 max-w-7xl transition-all">
+      {/* MAIN CONTENT AREA — bottom padding clears the mobile tab bar (+ the
+          floating check-in button on Home); md+ uses the sidebar instead. */}
+      <main className="flex-1 p-3 pb-32 md:p-6 md:pb-6 max-w-7xl transition-all">
         <Outlet context={contextValue} />
       </main>
+
+      {/* MOBILE BOTTOM TAB BAR */}
+      <BottomNav />
 
       {/* ACTION ERROR TOAST — surfaces failed shift actions (start/end/move). */}
       <AnimatePresence>

--- a/src/app/layout/BottomNav.tsx
+++ b/src/app/layout/BottomNav.tsx
@@ -1,0 +1,56 @@
+import { Link, useLocation } from 'react-router-dom';
+import { SquaresFourIcon, ChartBarIcon, ClockIcon, GearIcon, ShieldCheckIcon, type Icon } from '@phosphor-icons/react';
+import { useAuthContext } from '@features/auth/AuthContext';
+import { canViewAdminPanel } from '@features/admin/permissions';
+
+/**
+ * --- BOTTOM NAVIGATION (mobile) ---
+ * Persistent native-style tab bar. Replaces the previous hamburger-only nav as
+ * the primary way to move around on phones (the hamburger overlay stays for
+ * secondary actions: profile, theme, logout, location search). Hidden on md+.
+ */
+
+interface NavItem {
+    name: string;
+    icon: Icon;
+    route: string;
+}
+
+export function BottomNav() {
+    const { user } = useAuthContext();
+    const { pathname } = useLocation();
+
+    const items: NavItem[] = [
+        { name: 'Home', icon: SquaresFourIcon, route: '/' },
+        { name: 'Overview', icon: ChartBarIcon, route: '/overview' },
+        { name: 'Shifts', icon: ClockIcon, route: '/my-shifts' },
+        ...(user && canViewAdminPanel(user) ? [{ name: 'Admin', icon: ShieldCheckIcon, route: '/admin' }] : []),
+        { name: 'Settings', icon: GearIcon, route: '/settings' },
+    ];
+
+    return (
+        <nav
+            aria-label="Primary"
+            className="md:hidden fixed bottom-0 inset-x-0 z-40 bg-white/90 dark:bg-gray-900/90 backdrop-blur-xl border-t border-gray-200 dark:border-white/10 pb-[env(safe-area-inset-bottom)]"
+        >
+            <div className="flex items-stretch justify-around h-16">
+                {items.map((item) => {
+                    const active = item.route === pathname;
+                    return (
+                        <Link
+                            key={item.route}
+                            to={item.route}
+                            aria-current={active ? 'page' : undefined}
+                            className={`flex flex-col items-center justify-center gap-1 flex-1 min-w-0 active:scale-95 transition-transform ${
+                                active ? 'text-emerald-600 dark:text-emerald-400' : 'text-gray-400 dark:text-gray-500'
+                            }`}
+                        >
+                            <item.icon weight={active ? 'fill' : 'regular'} className="w-6 h-6" />
+                            <span className="text-[10px] font-bold tracking-tight">{item.name}</span>
+                        </Link>
+                    );
+                })}
+            </div>
+        </nav>
+    );
+}

--- a/src/features/admin/components/ActionButtons.tsx
+++ b/src/features/admin/components/ActionButtons.tsx
@@ -6,18 +6,18 @@ export function ActionButtons({ onEdit, onDelete }: { onEdit: () => void; onDele
         <div className="flex items-center gap-0.5">
             <button
                 onClick={onEdit}
-                className="p-1.5 sm:p-2 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:hover:bg-emerald-500/10 rounded-lg transition-colors"
+                className="p-2 sm:p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:hover:bg-emerald-500/10 rounded-lg transition-colors"
                 aria-label="Edit"
             >
-                <PencilSimpleIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" weight="bold" />
+                <PencilSimpleIcon className="w-4 h-4" weight="bold" />
             </button>
             {onDelete && (
                 <button
                     onClick={onDelete}
-                    className="p-1.5 sm:p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-500/10 rounded-lg transition-colors"
+                    className="p-2 sm:p-2.5 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-500/10 rounded-lg transition-colors"
                     aria-label="Delete"
                 >
-                    <TrashIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" weight="bold" />
+                    <TrashIcon className="w-4 h-4" weight="bold" />
                 </button>
             )}
         </div>

--- a/src/features/admin/components/Modal.tsx
+++ b/src/features/admin/components/Modal.tsx
@@ -1,11 +1,15 @@
 import { motion } from 'framer-motion';
 import { XIcon, WarningIcon } from '@phosphor-icons/react';
-import { useState, type ReactNode } from 'react';
+import { useState, useEffect, useRef, type ReactNode } from 'react';
 
 /**
  * --- MODAL ---
  * Reusable centered, animated modal shell used by every admin form.
- * Closes on backdrop click or the corner X.
+ *
+ * Mobile-hardened: the panel is capped at 90dvh with its body scrolling
+ * independently (so a tall form + the on-screen keyboard can't push the action
+ * buttons off-screen), the background scroll is locked while open, Escape and
+ * backdrop close it, focus is trapped inside, and it's announced as a dialog.
  */
 export function Modal({
     title,
@@ -18,9 +22,48 @@ export function Modal({
     onClose: () => void;
     children: ReactNode;
 }) {
+    const panelRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        // Lock background scroll while the modal is open.
+        const prevOverflow = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+
+        // Move focus into the dialog.
+        panelRef.current?.focus();
+
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                onClose();
+                return;
+            }
+            if (e.key !== 'Tab') return;
+            // Trap Tab focus within the panel.
+            const focusables = panelRef.current?.querySelectorAll<HTMLElement>(
+                'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+            );
+            if (!focusables || focusables.length === 0) return;
+            const first = focusables[0];
+            const last = focusables[focusables.length - 1];
+            if (e.shiftKey && document.activeElement === first) {
+                e.preventDefault();
+                last.focus();
+            } else if (!e.shiftKey && document.activeElement === last) {
+                e.preventDefault();
+                first.focus();
+            }
+        };
+
+        document.addEventListener('keydown', onKeyDown);
+        return () => {
+            document.body.style.overflow = prevOverflow;
+            document.removeEventListener('keydown', onKeyDown);
+        };
+    }, [onClose]);
+
     return (
         <motion.div
-            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+            className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -28,13 +71,18 @@ export function Modal({
             <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
 
             <motion.div
-                initial={{ opacity: 0, scale: 0.95, y: 12 }}
+                ref={panelRef}
+                role="dialog"
+                aria-modal="true"
+                aria-label={title}
+                tabIndex={-1}
+                initial={{ opacity: 0, scale: 0.97, y: 16 }}
                 animate={{ opacity: 1, scale: 1, y: 0 }}
-                exit={{ opacity: 0, scale: 0.95, y: 12 }}
+                exit={{ opacity: 0, scale: 0.97, y: 16 }}
                 transition={{ type: 'spring', stiffness: 400, damping: 30 }}
-                className="relative w-full max-w-md bg-white dark:bg-gray-900 rounded-3xl border border-gray-100 dark:border-gray-800 shadow-2xl overflow-hidden"
+                className="relative w-full max-w-md max-h-[90dvh] flex flex-col bg-white dark:bg-gray-900 rounded-t-3xl sm:rounded-3xl border border-gray-100 dark:border-gray-800 shadow-2xl overflow-hidden outline-none"
             >
-                <div className="flex items-start justify-between gap-4 p-5 border-b border-gray-50 dark:border-white/5">
+                <div className="flex items-start justify-between gap-4 p-5 border-b border-gray-50 dark:border-white/5 shrink-0">
                     <div className="min-w-0">
                         <h2 className="text-lg font-black text-gray-900 dark:text-white tracking-tight truncate">{title}</h2>
                         {subtitle && (
@@ -43,14 +91,17 @@ export function Modal({
                     </div>
                     <button
                         onClick={onClose}
-                        className="shrink-0 p-2 -m-1 text-gray-400 hover:text-gray-700 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/5 rounded-xl transition-colors"
+                        className="shrink-0 p-2.5 -m-1 text-gray-400 hover:text-gray-700 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/5 rounded-xl transition-colors"
                         aria-label="Close"
                     >
-                        <XIcon weight="bold" className="w-4 h-4" />
+                        <XIcon weight="bold" className="w-5 h-5" />
                     </button>
                 </div>
 
-                <div className="p-5">{children}</div>
+                {/* Scrollable body; safe-area padding so the last field clears the home indicator. */}
+                <div className="p-5 overflow-y-auto overscroll-contain pb-[calc(1.25rem+env(safe-area-inset-bottom))] sm:pb-5">
+                    {children}
+                </div>
             </motion.div>
         </motion.div>
     );

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -71,7 +71,7 @@ export function Dashboard({ onLocationSelect }: DashboardProps) {
 
   return (
     <>
-      <header className="sticky top-0 z-50 md:h-screen w-full md:w-1/3 lg:w-1/4 bg-white/40 dark:bg-gray-900/80 backdrop-blur-xl shadow-sm border-b md:border-b-0 md:border-r border-emerald-500/10 dark:border-white/5 transition-all duration-300">
+      <header className="sticky top-0 z-50 md:h-dvh w-full md:w-1/3 lg:w-1/4 bg-white/40 dark:bg-gray-900/80 backdrop-blur-xl shadow-sm border-b md:border-b-0 md:border-r border-emerald-500/10 dark:border-white/5 transition-all duration-300">
         <div className="flex flex-col md:h-full max-w-7xl mx-auto px-4 py-1.5 md:gap-2 md:py-4 pt-[calc(0.375rem+env(safe-area-inset-top,0px))]">
           <div className="shrink-0 flex justify-between items-center h-10 md:h-12 relative">
             <div className="flex items-center gap-3 z-10">

--- a/src/features/shifts/components/ActiveShift.tsx
+++ b/src/features/shifts/components/ActiveShift.tsx
@@ -118,7 +118,7 @@ export function ActiveShift() {
             </div>
 
             {/* --- MOBILE STICKY BUTTON --- */}
-            <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-gray-200 dark:border-white/10 bg-white/80 dark:bg-gray-900/80 backdrop-blur-xl p-4 pb-[calc(1rem+env(safe-area-inset-bottom))] shadow-2xl md:hidden transition-all duration-300">
+            <div className="fixed bottom-[calc(4rem+env(safe-area-inset-bottom))] left-0 right-0 z-50 bg-white/80 dark:bg-gray-900/80 backdrop-blur-xl p-4 shadow-2xl md:hidden transition-all duration-300">
                 <button
                     onClick={onEndShiftClick}
                     disabled={isDisabled}

--- a/src/features/shifts/components/CheckIn.tsx
+++ b/src/features/shifts/components/CheckIn.tsx
@@ -60,7 +60,7 @@ export function CheckIn() {
       </div>
 
       {/* --- MOBILE STICKY BUTTON --- */}
-      <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-gray-200 dark:border-white/10 bg-white/80 dark:bg-gray-900/80 backdrop-blur-xl p-4 pb-[calc(1rem+env(safe-area-inset-bottom))] shadow-2xl md:hidden transition-all duration-300">
+      <div className="fixed bottom-[calc(4rem+env(safe-area-inset-bottom))] left-0 right-0 z-50 bg-white/80 dark:bg-gray-900/80 backdrop-blur-xl p-4 shadow-2xl md:hidden transition-all duration-300">
         <button
           onClick={onStartShiftClick}
           disabled={isDisabled}


### PR DESCRIPTION
Phase 3 of the audit / roadmap H1.1.

- **M1 Modal** — 90dvh cap + scrolling body (keyboard-safe), background scroll lock, Escape/backdrop close, focus trap, `role=dialog`/`aria-modal`, safe-area, bottom-sheet on phones.
- **M2 Bottom tab bar** — persistent mobile nav (`BottomNav`); hamburger kept for secondary actions; Start/End-shift sticky buttons float above the bar; main padding reworked.
- **M3 Touch targets** — larger modal close + admin action buttons.
- **M4/M5** — `dvh` + safe-area insets (no more URL-bar/notch overflow).

Verified tsc/eslint/build. Best tested on a real device / mobile viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)