### PR TITLE
fix(ci): force npm install on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+    "installCommand": "npm install",
     "rewrites": [
         {
             "source": "/(.*)",


### PR DESCRIPTION
Deploys kept failing at install: the pinned `yarn install` (yarn 1) can't link vitest's `vite` peer dependency. Override `installCommand` to `npm install` in vercel.json (uses the committed package-lock.json). This is the actual fix; removing yarn.lock alone didn't change the install command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)