### PR TITLE
ci(h1.4): GitHub Actions — lint, test, build on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+# Verify every PR (and pushes to the release branches) before it can be merged:
+# type-check, lint, unit tests, and a production build. This would have caught
+# the broken build that previously only failed on Vercel.
+
+on:
+  pull_request:
+  push:
+    branches: [master, dev, preview]
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Build (tsc -b + vite build)
+        run: npm run build


### PR DESCRIPTION
Roadmap H1.4. Adds `.github/workflows/ci.yml`: `npm ci` + `npm run lint` + `npm test` + `npm run build` on every PR and on pushes to master/dev/preview, with concurrency cancellation. Catches build/test/lint regressions before merge (e.g. the recent Vercel-only failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)