### PR TITLE
feat(ui): monolithic compact tables on mobile too (admin + overview)

### DIFF
--- a/src/features/admin/AdminPage.tsx
+++ b/src/features/admin/AdminPage.tsx
@@ -169,7 +169,7 @@ function AdminPanel() {
             </header>
 
             {/* --- STATS --- */}
-            <div className={`grid gap-3 ${isSuperAdmin ? 'grid-cols-3' : 'grid-cols-2'}`}>
+            <div className={`grid gap-2 sm:gap-3 ${isSuperAdmin ? 'grid-cols-2 sm:grid-cols-3' : 'grid-cols-2'}`}>
                 <StatCard icon={UsersIcon} label="Employees" value={empCount} accent="emerald" />
                 <StatCard icon={MapPinIcon} label="Locations" value={locCount} accent="blue" />
                 {isSuperAdmin && <StatCard icon={BuildingsIcon} label="Organizations" value={orgCount} accent="violet" />}

--- a/src/features/admin/components/ActionButtons.tsx
+++ b/src/features/admin/components/ActionButtons.tsx
@@ -6,7 +6,7 @@ export function ActionButtons({ onEdit, onDelete }: { onEdit: () => void; onDele
         <div className="flex items-center gap-0.5">
             <button
                 onClick={onEdit}
-                className="p-2 sm:p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:hover:bg-emerald-500/10 rounded-lg transition-colors"
+                className="p-1.5 sm:p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:hover:bg-emerald-500/10 rounded-lg transition-colors"
                 aria-label="Edit"
             >
                 <PencilSimpleIcon className="w-4 h-4" weight="bold" />
@@ -14,7 +14,7 @@ export function ActionButtons({ onEdit, onDelete }: { onEdit: () => void; onDele
             {onDelete && (
                 <button
                     onClick={onDelete}
-                    className="p-2 sm:p-2.5 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-500/10 rounded-lg transition-colors"
+                    className="p-1.5 sm:p-2.5 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-500/10 rounded-lg transition-colors"
                     aria-label="Delete"
                 >
                     <TrashIcon className="w-4 h-4" weight="bold" />

--- a/src/features/admin/components/AdminStateViews.tsx
+++ b/src/features/admin/components/AdminStateViews.tsx
@@ -20,14 +20,14 @@ export function StatCard({
     accent: string;
 }) {
     return (
-        <div className="flex items-center gap-3 p-3 sm:p-4 bg-white dark:bg-gray-800/30 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm">
-            <div className={`w-10 h-10 rounded-xl flex items-center justify-center shrink-0 ${STAT_ACCENTS[accent]}`}>
-                <StatIcon className="w-5 h-5" weight="bold" />
+        <div className="p-2.5 sm:p-4 bg-white dark:bg-gray-800/30 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm min-w-0">
+            <div className="flex items-center gap-2 sm:gap-3 min-w-0">
+                <div className={`w-8 h-8 sm:w-10 sm:h-10 rounded-xl flex items-center justify-center shrink-0 ${STAT_ACCENTS[accent]}`}>
+                    <StatIcon className="w-4 h-4 sm:w-5 sm:h-5" weight="bold" />
+                </div>
+                <p className="text-xl sm:text-2xl font-black tracking-tight text-gray-900 dark:text-white leading-none">{value}</p>
             </div>
-            <div className="min-w-0">
-                <p className="text-display text-gray-900 dark:text-white leading-none">{value}</p>
-                <p className="text-micro text-gray-400 mt-1">{label}</p>
-            </div>
+            <p className="text-micro text-gray-400 mt-2 truncate">{label}</p>
         </div>
     );
 }

--- a/src/features/admin/components/EmployeesList.tsx
+++ b/src/features/admin/components/EmployeesList.tsx
@@ -52,8 +52,8 @@ function AdminBadgeWithTooltip() {
 
 function EmployeeIdentity({ employee, isSelf }: { employee: Profile; isSelf: boolean }) {
     return (
-        <div className="flex items-center gap-3 min-w-0">
-            <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-full bg-emerald-100 dark:bg-emerald-900/40 border-2 border-white dark:border-white/10 flex items-center justify-center text-emerald-700 dark:text-emerald-400 text-micro shrink-0">
+        <div className="flex items-center gap-2.5 min-w-0">
+            <div className="w-8 h-8 sm:w-9 sm:h-9 rounded-full bg-emerald-100 dark:bg-emerald-900/40 border-2 border-white dark:border-white/10 flex items-center justify-center text-emerald-700 dark:text-emerald-400 text-micro shrink-0">
                 {getFullInitials(employee.first_name, employee.last_name)}
             </div>
             <div className="min-w-0">
@@ -76,7 +76,7 @@ function EmployeeIdentity({ employee, isSelf }: { employee: Profile; isSelf: boo
 
 function RoleBadge({ role }: { role: Profile['role'] }) {
     return (
-        <span className={`px-2 py-1 text-micro rounded-md ${getRoleBadgeColor(role.name)}`}>{role.name}</span>
+        <span className={`px-2 py-1 text-micro rounded-md whitespace-nowrap ${getRoleBadgeColor(role.name)}`}>{role.name}</span>
     );
 }
 
@@ -96,8 +96,8 @@ export function EmployeesList({
     const manageable = (emp: Profile) => (currentUser ? canManageMember(currentUser, emp) : false);
 
     const columns: Column<Profile>[] = [
-        { key: 'employee', header: 'Employee', render: (emp) => <EmployeeIdentity employee={emp} isSelf={emp.id === currentUser?.id} /> },
-        { key: 'email', header: 'Email', render: (emp) => <span className="text-body text-gray-500 dark:text-gray-400 truncate">{emp.email}</span> },
+        { key: 'employee', header: 'Employee', render: (emp) => <EmployeeIdentity employee={emp} isSelf={emp.id === currentUser?.id} />, className: 'max-w-[55vw]' },
+        { key: 'email', header: 'Email', hideOnMobile: true, render: (emp) => <span className="text-body text-gray-500 dark:text-gray-400 truncate">{emp.email}</span> },
         { key: 'role', header: 'Role', align: 'right', render: (emp) => <RoleBadge role={emp.role} /> },
         {
             key: 'actions',
@@ -120,18 +120,6 @@ export function EmployeesList({
             isLoading={isLoading}
             loadingState={<LoadingState label="employees" />}
             emptyState={<EmptyState label="employees" />}
-            mobileCard={(emp) => (
-                <div className="flex items-center gap-2 p-1.5 bg-white dark:bg-gray-800/40 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm">
-                    <div className="min-w-0 flex-1">
-                        <EmployeeIdentity employee={emp} isSelf={emp.id === currentUser?.id} />
-                        <p className="text-micro text-gray-400 truncate mt-1 pl-12">{emp.email}</p>
-                    </div>
-                    <div className="flex items-center gap-2 shrink-0">
-                        <RoleBadge role={emp.role} />
-                        {manageable(emp) && <ActionButtons onEdit={() => onEdit(emp)} onDelete={() => onDelete(emp)} />}
-                    </div>
-                </div>
-            )}
         />
     );
 }

--- a/src/features/admin/components/EmployeesList.tsx
+++ b/src/features/admin/components/EmployeesList.tsx
@@ -50,6 +50,12 @@ function AdminBadgeWithTooltip() {
     );
 }
 
+function RoleBadge({ role }: { role: Profile['role'] }) {
+    return (
+        <span className={`inline-block px-1.5 py-1 text-micro rounded-md whitespace-nowrap ${getRoleBadgeColor(role.name)}`}>{role.name}</span>
+    );
+}
+
 function EmployeeIdentity({ employee, isSelf }: { employee: Profile; isSelf: boolean }) {
     return (
         <div className="flex items-center gap-2.5 min-w-0">
@@ -69,14 +75,12 @@ function EmployeeIdentity({ employee, isSelf }: { employee: Profile; isSelf: boo
                     )}
                 </div>
                 <p className="text-micro text-emerald-600 dark:text-emerald-400 truncate normal-case">@{employee.username}</p>
+                {/* Role lives in its own column on sm+; stacked here to stay compact on mobile. */}
+                <div className="sm:hidden mt-1">
+                    <RoleBadge role={employee.role} />
+                </div>
             </div>
         </div>
-    );
-}
-
-function RoleBadge({ role }: { role: Profile['role'] }) {
-    return (
-        <span className={`px-2 py-1 text-micro rounded-md whitespace-nowrap ${getRoleBadgeColor(role.name)}`}>{role.name}</span>
     );
 }
 
@@ -96,9 +100,9 @@ export function EmployeesList({
     const manageable = (emp: Profile) => (currentUser ? canManageMember(currentUser, emp) : false);
 
     const columns: Column<Profile>[] = [
-        { key: 'employee', header: 'Employee', render: (emp) => <EmployeeIdentity employee={emp} isSelf={emp.id === currentUser?.id} />, className: 'max-w-[55vw]' },
+        { key: 'employee', header: 'Employee', render: (emp) => <EmployeeIdentity employee={emp} isSelf={emp.id === currentUser?.id} />, className: 'max-w-[72vw] sm:max-w-none' },
         { key: 'email', header: 'Email', hideOnMobile: true, render: (emp) => <span className="text-body text-gray-500 dark:text-gray-400 truncate">{emp.email}</span> },
-        { key: 'role', header: 'Role', align: 'right', render: (emp) => <RoleBadge role={emp.role} /> },
+        { key: 'role', header: 'Role', align: 'right', hideOnMobile: true, render: (emp) => <RoleBadge role={emp.role} /> },
         {
             key: 'actions',
             header: '',

--- a/src/features/admin/components/LocationsList.tsx
+++ b/src/features/admin/components/LocationsList.tsx
@@ -12,13 +12,13 @@ export interface LocationRow {
 
 function LocationIdentity({ loc }: { loc: LocationRow }) {
     return (
-        <div className="flex items-center gap-3 min-w-0">
-            <div className="w-9 h-9 rounded-xl bg-blue-50 dark:bg-blue-900/20 text-blue-600 flex items-center justify-center shrink-0">
-                <MapPinIcon className="w-5 h-5" weight="bold" />
+        <div className="flex items-center gap-2.5 min-w-0">
+            <div className="w-8 h-8 sm:w-9 sm:h-9 rounded-xl bg-blue-50 dark:bg-blue-900/20 text-blue-600 flex items-center justify-center shrink-0">
+                <MapPinIcon className="w-4 h-4 sm:w-5 sm:h-5" weight="bold" />
             </div>
             <div className="min-w-0">
                 <h3 className="text-body-strong dark:text-white truncate">{loc.name}</h3>
-                <p className="text-micro text-gray-400">{loc.organizationName}</p>
+                <p className="text-micro text-gray-400 truncate">{loc.organizationName}</p>
             </div>
         </div>
     );
@@ -38,9 +38,9 @@ export function LocationsList({
     onDelete: (loc: LocationRow) => void;
 }) {
     const columns: Column<LocationRow>[] = [
-        { key: 'loc', header: 'Location', render: (loc) => <LocationIdentity loc={loc} /> },
-        { key: 'org', header: 'Organization', render: (loc) => <span className="text-body text-gray-500 dark:text-gray-400 truncate">{loc.organizationName}</span> },
-        { key: 'id', header: 'ID', align: 'right', render: (loc) => <span className="text-micro text-gray-400">{loc.id.slice(0, 8)}</span> },
+        { key: 'loc', header: 'Location', render: (loc) => <LocationIdentity loc={loc} />, className: 'max-w-[60vw]' },
+        { key: 'org', header: 'Organization', hideOnMobile: true, render: (loc) => <span className="text-body text-gray-500 dark:text-gray-400 truncate">{loc.organizationName}</span> },
+        { key: 'id', header: 'ID', align: 'right', hideOnMobile: true, render: (loc) => <span className="text-micro text-gray-400 normal-case">{loc.id.slice(0, 8)}</span> },
         ...(canManage
             ? [{ key: 'actions', header: '', align: 'right' as const, render: (loc: LocationRow) => <div className="flex justify-end"><ActionButtons onEdit={() => onEdit(loc)} onDelete={() => onDelete(loc)} /></div> }]
             : []),
@@ -54,16 +54,6 @@ export function LocationsList({
             isLoading={isLoading}
             loadingState={<LoadingState label="locations" />}
             emptyState={<EmptyState label="locations" />}
-            mobileCard={(loc) => (
-                <div className="flex items-center gap-3 p-2 bg-white dark:bg-gray-800/40 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm">
-                    <LocationIdentity loc={loc} />
-                    {canManage && (
-                        <div className="ml-auto pr-1">
-                            <ActionButtons onEdit={() => onEdit(loc)} onDelete={() => onDelete(loc)} />
-                        </div>
-                    )}
-                </div>
-            )}
         />
     );
 }

--- a/src/features/admin/components/LocationsList.tsx
+++ b/src/features/admin/components/LocationsList.tsx
@@ -38,9 +38,9 @@ export function LocationsList({
     onDelete: (loc: LocationRow) => void;
 }) {
     const columns: Column<LocationRow>[] = [
-        { key: 'loc', header: 'Location', render: (loc) => <LocationIdentity loc={loc} />, className: 'max-w-[60vw]' },
+        { key: 'loc', header: 'Location', render: (loc) => <LocationIdentity loc={loc} />, className: 'max-w-[70vw] sm:max-w-none' },
         { key: 'org', header: 'Organization', hideOnMobile: true, render: (loc) => <span className="text-body text-gray-500 dark:text-gray-400 truncate">{loc.organizationName}</span> },
-        { key: 'id', header: 'ID', align: 'right', hideOnMobile: true, render: (loc) => <span className="text-micro text-gray-400 normal-case">{loc.id.slice(0, 8)}</span> },
+        { key: 'id', header: 'ID', align: 'right', hideOnMobile: true, render: (loc) => <span className="text-micro text-gray-400 normal-case whitespace-nowrap">{loc.id.slice(0, 8)}</span> },
         ...(canManage
             ? [{ key: 'actions', header: '', align: 'right' as const, render: (loc: LocationRow) => <div className="flex justify-end"><ActionButtons onEdit={() => onEdit(loc)} onDelete={() => onDelete(loc)} /></div> }]
             : []),

--- a/src/features/admin/components/OrganizationsList.tsx
+++ b/src/features/admin/components/OrganizationsList.tsx
@@ -13,6 +13,10 @@ function OrgIdentity({ org }: { org: Organization }) {
             <div className="min-w-0">
                 <h3 className="text-body-strong dark:text-white truncate">{org.name}</h3>
                 <p className="text-micro text-gray-400 truncate normal-case">{org.slug}</p>
+                {/* Counts have their own columns on sm+; stacked here to stay compact on mobile. */}
+                <p className="sm:hidden text-micro text-gray-400 mt-1">
+                    {org.locations.length} locs · {org.profiles.length} users
+                </p>
             </div>
         </div>
     );
@@ -30,9 +34,9 @@ export function OrganizationsList({
     onDelete: (org: Organization) => void;
 }) {
     const columns: Column<Organization>[] = [
-        { key: 'org', header: 'Organization', render: (org) => <OrgIdentity org={org} />, className: 'max-w-[60vw]' },
+        { key: 'org', header: 'Organization', render: (org) => <OrgIdentity org={org} />, className: 'max-w-[72vw] sm:max-w-none' },
         { key: 'locs', header: 'Locs', align: 'right', hideOnMobile: true, render: (org) => <span className="text-metric-sm dark:text-white">{org.locations.length}</span> },
-        { key: 'users', header: 'Users', align: 'right', render: (org) => <span className="text-metric-sm dark:text-white">{org.profiles.length}</span> },
+        { key: 'users', header: 'Users', align: 'right', hideOnMobile: true, render: (org) => <span className="text-metric-sm dark:text-white">{org.profiles.length}</span> },
         { key: 'actions', header: '', align: 'right', render: (org) => <div className="flex justify-end"><ActionButtons onEdit={() => onEdit(org)} onDelete={() => onDelete(org)} /></div> },
     ];
 

--- a/src/features/admin/components/OrganizationsList.tsx
+++ b/src/features/admin/components/OrganizationsList.tsx
@@ -6,13 +6,13 @@ import { LoadingState, EmptyState } from './AdminStateViews';
 
 function OrgIdentity({ org }: { org: Organization }) {
     return (
-        <div className="flex items-center gap-3 min-w-0">
-            <div className="w-9 h-9 rounded-xl bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 flex items-center justify-center shrink-0">
-                <BuildingsIcon className="w-5 h-5" weight="bold" />
+        <div className="flex items-center gap-2.5 min-w-0">
+            <div className="w-8 h-8 sm:w-9 sm:h-9 rounded-xl bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 flex items-center justify-center shrink-0">
+                <BuildingsIcon className="w-4 h-4 sm:w-5 sm:h-5" weight="bold" />
             </div>
             <div className="min-w-0">
                 <h3 className="text-body-strong dark:text-white truncate">{org.name}</h3>
-                <p className="text-micro text-gray-400">{org.slug}</p>
+                <p className="text-micro text-gray-400 truncate normal-case">{org.slug}</p>
             </div>
         </div>
     );
@@ -30,8 +30,8 @@ export function OrganizationsList({
     onDelete: (org: Organization) => void;
 }) {
     const columns: Column<Organization>[] = [
-        { key: 'org', header: 'Organization', render: (org) => <OrgIdentity org={org} /> },
-        { key: 'locs', header: 'Locations', align: 'right', render: (org) => <span className="text-metric-sm dark:text-white">{org.locations.length}</span> },
+        { key: 'org', header: 'Organization', render: (org) => <OrgIdentity org={org} />, className: 'max-w-[60vw]' },
+        { key: 'locs', header: 'Locs', align: 'right', hideOnMobile: true, render: (org) => <span className="text-metric-sm dark:text-white">{org.locations.length}</span> },
         { key: 'users', header: 'Users', align: 'right', render: (org) => <span className="text-metric-sm dark:text-white">{org.profiles.length}</span> },
         { key: 'actions', header: '', align: 'right', render: (org) => <div className="flex justify-end"><ActionButtons onEdit={() => onEdit(org)} onDelete={() => onDelete(org)} /></div> },
     ];
@@ -44,24 +44,6 @@ export function OrganizationsList({
             isLoading={isLoading}
             loadingState={<LoadingState label="organizations" />}
             emptyState={<EmptyState label="organizations" />}
-            mobileCard={(org) => (
-                <div className="flex items-center gap-3 p-2 bg-white dark:bg-gray-800/40 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm">
-                    <OrgIdentity org={org} />
-                    <div className="flex items-center gap-4 ml-auto pr-1">
-                        <div className="flex gap-4 text-center">
-                            <div>
-                                <p className="text-metric-sm dark:text-white">{org.locations.length}</p>
-                                <p className="text-micro text-gray-400">Locs</p>
-                            </div>
-                            <div>
-                                <p className="text-metric-sm dark:text-white">{org.profiles.length}</p>
-                                <p className="text-micro text-gray-400">Users</p>
-                            </div>
-                        </div>
-                        <ActionButtons onEdit={() => onEdit(org)} onDelete={() => onDelete(org)} />
-                    </div>
-                </div>
-            )}
         />
     );
 }

--- a/src/features/shifts/OverviewPage.tsx
+++ b/src/features/shifts/OverviewPage.tsx
@@ -14,6 +14,7 @@ import {
 } from '@phosphor-icons/react';
 import { useShiftContext } from './ShiftContext';
 import { type Shift } from '@shared/types';
+import { DataTable, type Column } from '@shared/components/DataTable';
 import { shiftHours, fmtHours, fmtDuration, shiftGrossHours, shiftBreakHours } from './shiftStats';
 
 // PDF Libraries
@@ -205,6 +206,75 @@ export default function OverviewPage() {
   }, [userShifts, selectedMonth]);
 
   const maxWeekday = Math.max(...stats.byWeekday, 0.1);
+
+  // Shift history rendered through the shared DataTable so it matches the admin
+  // tables exactly (one compact monolithic table on every breakpoint).
+  const historyColumns: Column<Shift>[] = [
+    {
+      key: 'date',
+      header: 'Date',
+      className: 'whitespace-nowrap',
+      footer: <span className="text-label text-gray-400">Total</span>,
+      render: (shift) => {
+        const date = new Date(shift.started_at);
+        return (
+          <div className="flex flex-col">
+            <span className="text-small-strong dark:text-white">
+              {date.getDate()} {date.toLocaleDateString(undefined, { month: 'short' })}
+            </span>
+            <span className="text-micro text-gray-400">{WEEKDAYS[(date.getDay() + 6) % 7]}</span>
+          </div>
+        );
+      },
+    },
+    {
+      key: 'location',
+      header: 'Location & Time',
+      className: 'max-w-[42vw] sm:max-w-none',
+      render: (shift) => (
+        <div className="flex flex-col">
+          <span className="text-small-strong text-gray-700 dark:text-gray-200 truncate">{locationName(shift.location_id)}</span>
+          <span className="text-caption text-gray-400 tabular-nums">{fmtTimeRange(shift)}</span>
+        </div>
+      ),
+    },
+    {
+      key: 'gross',
+      header: 'Gross',
+      align: 'right',
+      className: 'text-xs font-bold tabular-nums text-gray-600 dark:text-gray-300',
+      footer: <span className="text-xs font-black tabular-nums dark:text-white">{fmtHours(stats.totalGross)}</span>,
+      render: (shift) => fmtDuration(shiftGrossHours(shift)),
+    },
+    {
+      key: 'break',
+      header: 'Break',
+      align: 'right',
+      className: 'text-xs font-bold tabular-nums text-amber-500',
+      footer: <span className="text-xs font-black tabular-nums text-amber-500">-{fmtHours(stats.totalBreak)}</span>,
+      render: (shift) => {
+        const brk = shiftBreakHours(shift);
+        return brk > 0 ? `-${fmtDuration(brk)}` : '—';
+      },
+    },
+    {
+      key: 'net',
+      header: 'Net',
+      align: 'right',
+      footer: <span className="text-xs font-black tabular-nums text-emerald-600 dark:text-emerald-400">{fmtHours(stats.totalHours)}</span>,
+      render: (shift) => {
+        const ongoing = !shift.ended_at;
+        return (
+          <>
+            <span className={`text-xs font-black tabular-nums ${ongoing ? 'text-amber-500' : 'text-emerald-600 dark:text-emerald-400'}`}>
+              {fmtDuration(shiftHours(shift))}
+            </span>
+            {ongoing && <span className="block text-micro text-amber-500">Live</span>}
+          </>
+        );
+      },
+    },
+  ];
 
   const exportToPDF = () => {
     const doc = new jsPDF();
@@ -410,101 +480,7 @@ export default function OverviewPage() {
               Net = Gross − mandatory breaks (−30 min from 6h, −1h from 12h per shift).
             </p>
 
-            {/* DESKTOP TABLE */}
-            <div className="hidden sm:block bg-white dark:bg-gray-900/40 rounded-3xl border border-gray-100 dark:border-gray-800 overflow-hidden shadow-sm">
-              <table className="w-full text-left border-collapse">
-                <thead>
-                  <tr className="border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/30">
-                    <th className="px-4 py-3 text-label text-gray-400">Date</th>
-                    <th className="px-4 py-3 text-label text-gray-400">Location &amp; Time</th>
-                    <th className="px-4 py-3 text-label text-gray-400 text-right">Gross</th>
-                    <th className="px-4 py-3 text-label text-gray-400 text-right">Break</th>
-                    <th className="px-4 py-3 text-label text-gray-400 text-right">Net</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-50 dark:divide-gray-800/50">
-                  {stats.shifts.map((shift) => {
-                    const ongoing = !shift.ended_at;
-                    const gross = shiftGrossHours(shift);
-                    const brk = shiftBreakHours(shift);
-                    const net = shiftHours(shift);
-                    const date = new Date(shift.started_at);
-                    return (
-                      <tr key={shift.id} className="hover:bg-gray-50/80 dark:hover:bg-gray-800/20 transition-colors">
-                        <td className="px-4 py-3 whitespace-nowrap">
-                          <div className="flex flex-col">
-                            <span className="text-small-strong dark:text-white">
-                              {date.getDate()} {date.toLocaleDateString(undefined, { month: 'short' })}
-                            </span>
-                            <span className="text-micro text-gray-400">
-                              {WEEKDAYS[(date.getDay() + 6) % 7]}
-                            </span>
-                          </div>
-                        </td>
-                        <td className="px-4 py-3">
-                          <div className="flex flex-col">
-                            <span className="text-small-strong text-gray-700 dark:text-gray-200 truncate">{locationName(shift.location_id)}</span>
-                            <span className="text-caption text-gray-400 tabular-nums">{fmtTimeRange(shift)}</span>
-                          </div>
-                        </td>
-                        <td className="px-4 py-3 text-right text-xs font-bold tabular-nums text-gray-600 dark:text-gray-300">{fmtDuration(gross)}</td>
-                        <td className="px-4 py-3 text-right text-xs font-bold tabular-nums text-amber-500">{brk > 0 ? `-${fmtDuration(brk)}` : '—'}</td>
-                        <td className="px-4 py-3 text-right">
-                          <span className={`text-xs font-black tabular-nums ${ongoing ? 'text-amber-500' : 'text-emerald-600 dark:text-emerald-400'}`}>{fmtDuration(net)}</span>
-                          {ongoing && <span className="block text-micro text-amber-500">Live</span>}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-                <tfoot>
-                  <tr className="border-t border-gray-100 dark:border-gray-800 bg-gray-50/60 dark:bg-gray-800/40">
-                    <td className="px-4 py-3 text-label text-gray-400" colSpan={2}>Total</td>
-                    <td className="px-4 py-3 text-right text-xs font-black tabular-nums dark:text-white">{fmtHours(stats.totalGross)}</td>
-                    <td className="px-4 py-3 text-right text-xs font-black tabular-nums text-amber-500">-{fmtHours(stats.totalBreak)}</td>
-                    <td className="px-4 py-3 text-right text-xs font-black tabular-nums text-emerald-600 dark:text-emerald-400">{fmtHours(stats.totalHours)}</td>
-                  </tr>
-                </tfoot>
-              </table>
-            </div>
-
-            {/* MOBILE CARDS */}
-            <div className="sm:hidden space-y-2">
-              {stats.shifts.map((shift) => {
-                const ongoing = !shift.ended_at;
-                const gross = shiftGrossHours(shift);
-                const brk = shiftBreakHours(shift);
-                const net = shiftHours(shift);
-                const date = new Date(shift.started_at);
-                return (
-                  <div key={shift.id} className="flex items-center gap-3 p-3 bg-white dark:bg-gray-800/40 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm">
-                    <div className="flex flex-col items-center justify-center w-11 shrink-0">
-                      <span className="text-metric-sm dark:text-white leading-none">{date.getDate()}</span>
-                      <span className="text-micro text-gray-400">{WEEKDAYS[(date.getDay() + 6) % 7]}</span>
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <p className="text-small-strong text-gray-800 dark:text-gray-100 truncate">{locationName(shift.location_id)}</p>
-                      <p className="text-caption text-gray-400 tabular-nums">{fmtTimeRange(shift)}</p>
-                      <p className="text-caption text-gray-400 tabular-nums mt-0.5">
-                        Gross {fmtDuration(gross)}{brk > 0 ? ` · Break -${fmtDuration(brk)}` : ''}
-                      </p>
-                    </div>
-                    <div className="text-right shrink-0">
-                      <span className={`text-metric-sm ${ongoing ? 'text-amber-500' : 'text-emerald-600 dark:text-emerald-400'}`}>{fmtDuration(net)}</span>
-                      <span className="block text-micro text-gray-400">{ongoing ? 'Live' : 'Net'}</span>
-                    </div>
-                  </div>
-                );
-              })}
-              <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/60 rounded-2xl border border-gray-100 dark:border-gray-800">
-                <span className="text-micro text-gray-400">Total</span>
-                <span className="text-metric-sm">
-                  <span className="text-gray-500 dark:text-gray-400">{fmtHours(stats.totalGross)}</span>
-                  <span className="text-amber-500"> −{fmtHours(stats.totalBreak)}</span>
-                  <span className="text-emerald-600 dark:text-emerald-400"> = {fmtHours(stats.totalHours)}</span>
-                </span>
-              </div>
-            </div>
+            <DataTable rows={stats.shifts} rowKey={(s) => s.id} columns={historyColumns} />
           </div>
         </>
       )}

--- a/src/features/shifts/OverviewPage.tsx
+++ b/src/features/shifts/OverviewPage.tsx
@@ -230,18 +230,32 @@ export default function OverviewPage() {
     {
       key: 'location',
       header: 'Location & Time',
-      className: 'max-w-[42vw] sm:max-w-none',
-      render: (shift) => (
-        <div className="flex flex-col">
-          <span className="text-small-strong text-gray-700 dark:text-gray-200 truncate">{locationName(shift.location_id)}</span>
-          <span className="text-caption text-gray-400 tabular-nums">{fmtTimeRange(shift)}</span>
-        </div>
+      className: 'max-w-[46vw] sm:max-w-none',
+      // On mobile the Gross/Break columns are hidden to fit; surface them here.
+      footer: (
+        <span className="sm:hidden text-caption text-gray-500 dark:text-gray-400 tabular-nums">
+          {fmtHours(stats.totalGross)} · −{fmtHours(stats.totalBreak)}
+        </span>
       ),
+      render: (shift) => {
+        const gross = shiftGrossHours(shift);
+        const brk = shiftBreakHours(shift);
+        return (
+          <div className="flex flex-col min-w-0">
+            <span className="text-small-strong text-gray-700 dark:text-gray-200 truncate">{locationName(shift.location_id)}</span>
+            <span className="text-caption text-gray-400 tabular-nums">{fmtTimeRange(shift)}</span>
+            <span className="sm:hidden text-caption text-gray-400 tabular-nums">
+              Gross {fmtDuration(gross)}{brk > 0 ? ` · −${fmtDuration(brk)}` : ''}
+            </span>
+          </div>
+        );
+      },
     },
     {
       key: 'gross',
       header: 'Gross',
       align: 'right',
+      hideOnMobile: true,
       className: 'text-xs font-bold tabular-nums text-gray-600 dark:text-gray-300',
       footer: <span className="text-xs font-black tabular-nums dark:text-white">{fmtHours(stats.totalGross)}</span>,
       render: (shift) => fmtDuration(shiftGrossHours(shift)),
@@ -250,6 +264,7 @@ export default function OverviewPage() {
       key: 'break',
       header: 'Break',
       align: 'right',
+      hideOnMobile: true,
       className: 'text-xs font-bold tabular-nums text-amber-500',
       footer: <span className="text-xs font-black tabular-nums text-amber-500">-{fmtHours(stats.totalBreak)}</span>,
       render: (shift) => {

--- a/src/shared/components/DataTable.tsx
+++ b/src/shared/components/DataTable.tsx
@@ -47,7 +47,7 @@ const ALIGN: Record<NonNullable<Column<unknown>['align']>, string> = {
 };
 
 // Compact on phones, roomier on sm+. `hideOnMobile` columns appear from sm up.
-const cellPad = 'px-2.5 py-2 sm:px-4 sm:py-3';
+const cellPad = 'px-2 py-2.5 sm:px-4 sm:py-3';
 const mobileHidden = 'hidden sm:table-cell';
 
 /**

--- a/src/shared/components/DataTable.tsx
+++ b/src/shared/components/DataTable.tsx
@@ -3,9 +3,10 @@ import type { ReactNode } from 'react';
 /**
  * A single column definition for {@link DataTable}.
  *
- * Columns drive the desktop `<table>` layout. On mobile the table collapses to
- * stacked cards — either auto-generated from these columns (label/value pairs)
- * or fully custom via {@link DataTableProps.mobileCard}.
+ * The table renders as ONE real `<table>` on every breakpoint (no separate
+ * mobile card layout) — compact on phones, roomier on `sm+`. Columns that are
+ * secondary on small screens can opt out with {@link Column.hideOnMobile}; the
+ * container also scrolls horizontally as a safety net so nothing ever clips.
  */
 export interface Column<T> {
   /** Stable identifier for the column (used as React key). */
@@ -20,8 +21,10 @@ export interface Column<T> {
   className?: string;
   /** Extra classes applied to the `<th>`. */
   headerClassName?: string;
-  /** Hide this column when the table auto-stacks into mobile cards. */
+  /** Hide this column on mobile (shown from `sm` up). */
   hideOnMobile?: boolean;
+  /** Optional footer cell (e.g. totals). If any column sets this, a `tfoot` renders. */
+  footer?: ReactNode;
 }
 
 interface DataTableProps<T> {
@@ -29,14 +32,6 @@ interface DataTableProps<T> {
   rows: T[];
   /** Stable key for each row. */
   rowKey: (row: T) => string;
-  /**
-   * Custom mobile card renderer. When provided it fully replaces the
-   * auto-stacked mobile layout, giving each surface a tailored card while
-   * sharing the desktop table chrome. Falls back to label/value stacking.
-   */
-  mobileCard?: (row: T) => ReactNode;
-  /** Optional full-width footer (e.g. totals) — desktop `tfoot` + mobile card. */
-  footer?: ReactNode;
   isLoading?: boolean;
   /** Shown while `isLoading` and there are no rows yet. */
   loadingState?: ReactNode;
@@ -51,17 +46,20 @@ const ALIGN: Record<NonNullable<Column<unknown>['align']>, string> = {
   center: 'text-center',
 };
 
+// Compact on phones, roomier on sm+. `hideOnMobile` columns appear from sm up.
+const cellPad = 'px-2.5 py-2 sm:px-4 sm:py-3';
+const mobileHidden = 'hidden sm:table-cell';
+
 /**
- * Responsive, generic data table: a real `<table>` on `sm+` and stacked cards
- * on mobile. Centralizes table chrome (header, dividers, hover, rounded card
- * container) so feature surfaces only describe their columns.
+ * Responsive, generic data table. A single `<table>` on all breakpoints —
+ * compact and monolithic — sharing one look across Overview and the admin
+ * panel. Centralizes the table chrome (rounded container, header, dividers,
+ * hover, footer, loading/empty states) so feature surfaces only declare columns.
  */
 export function DataTable<T>({
   columns,
   rows,
   rowKey,
-  mobileCard,
-  footer,
   isLoading,
   loadingState,
   emptyState,
@@ -70,19 +68,20 @@ export function DataTable<T>({
   if (isLoading && rows.length === 0) return <>{loadingState ?? null}</>;
   if (rows.length === 0) return <>{emptyState ?? null}</>;
 
-  const mobileColumns = columns.filter((c) => !c.hideOnMobile);
+  const hasFooter = columns.some((c) => c.footer !== undefined);
 
   return (
-    <>
-      {/* DESKTOP TABLE */}
-      <div className="hidden sm:block bg-white dark:bg-gray-900/40 rounded-3xl border border-gray-100 dark:border-gray-800 overflow-hidden shadow-sm">
+    <div className="bg-white dark:bg-gray-900/40 rounded-2xl sm:rounded-3xl border border-gray-100 dark:border-gray-800 overflow-hidden shadow-sm">
+      <div className="overflow-x-auto">
         <table className="w-full text-left border-collapse">
           <thead>
             <tr className="border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/30">
               {columns.map((col) => (
                 <th
                   key={col.key}
-                  className={`px-4 py-3 text-label text-gray-400 ${ALIGN[col.align ?? 'left']} ${col.headerClassName ?? ''}`}
+                  className={`${cellPad} text-label text-gray-400 whitespace-nowrap ${ALIGN[col.align ?? 'left']} ${
+                    col.hideOnMobile ? mobileHidden : ''
+                  } ${col.headerClassName ?? ''}`}
                 >
                   {col.header}
                 </th>
@@ -99,51 +98,36 @@ export function DataTable<T>({
                 }`}
               >
                 {columns.map((col) => (
-                  <td key={col.key} className={`px-4 py-3 ${ALIGN[col.align ?? 'left']} ${col.className ?? ''}`}>
+                  <td
+                    key={col.key}
+                    className={`${cellPad} ${ALIGN[col.align ?? 'left']} ${col.hideOnMobile ? mobileHidden : ''} ${
+                      col.className ?? ''
+                    }`}
+                  >
                     {col.render(row)}
                   </td>
                 ))}
               </tr>
             ))}
           </tbody>
-          {footer && (
+          {hasFooter && (
             <tfoot>
               <tr className="border-t border-gray-100 dark:border-gray-800 bg-gray-50/60 dark:bg-gray-800/40">
-                <td colSpan={columns.length} className="px-4 py-3">
-                  {footer}
-                </td>
+                {columns.map((col) => (
+                  <td
+                    key={col.key}
+                    className={`${cellPad} whitespace-nowrap ${ALIGN[col.align ?? 'left']} ${
+                      col.hideOnMobile ? mobileHidden : ''
+                    }`}
+                  >
+                    {col.footer}
+                  </td>
+                ))}
               </tr>
             </tfoot>
           )}
         </table>
       </div>
-
-      {/* MOBILE CARDS */}
-      <div className="sm:hidden space-y-2">
-        {rows.map((row) =>
-          mobileCard ? (
-            <div key={rowKey(row)}>{mobileCard(row)}</div>
-          ) : (
-            <div
-              key={rowKey(row)}
-              onClick={onRowClick ? () => onRowClick(row) : undefined}
-              className="p-3 bg-white dark:bg-gray-800/40 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm space-y-1"
-            >
-              {mobileColumns.map((col) => (
-                <div key={col.key} className="flex items-center justify-between gap-3">
-                  {col.header ? <span className="text-micro text-gray-400">{col.header}</span> : <span />}
-                  <span className="text-body-strong dark:text-white min-w-0 truncate">{col.render(row)}</span>
-                </div>
-              ))}
-            </div>
-          ),
-        )}
-        {footer && (
-          <div className="p-3 bg-gray-50 dark:bg-gray-800/60 rounded-2xl border border-gray-100 dark:border-gray-800">
-            {footer}
-          </div>
-        )}
-      </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
Redesigns the admin panel (and unifies Overview) so the data renders as **one compact, monolithic `<table>` on every breakpoint** — including mobile — instead of switching to cards on phones. The admin tabs now match the Overview table look exactly.

### Changes
- **DataTable**: dropped the separate mobile-card layout. Now a single responsive `<table>`:
  - Compact responsive padding (`px-2.5 py-2` on mobile → `px-4 py-3` on `sm+`).
  - `hideOnMobile` per column → secondary columns (`hidden sm:table-cell`) drop out on phones to stay compact.
  - Per-column aligned `footer` (proper totals row, replaces the single full-width cell).
  - Horizontal-scroll safety net (`overflow-x-auto`) so nothing ever clips.
- **Admin** Employees / Locations / Organizations: real tables on mobile too (no cards). Compact identity cells (smaller avatars, truncating name + `@username` / slug / org). On phones: Employees hides Email; Locations hides Org + ID hash; Organizations hides Locs count.
- **Overview** history: converted its bespoke desktop-table + mobile-card pair to the same shared DataTable (with totals footer), so Overview and Admin are pixel-consistent.

### Verification
- `corepack yarn typecheck` ✓ · `lint` ✓ (0 errors, 4 pre-existing warnings) · `test` ✓ (26/26) · `build` ✓
- Login page smoke-checked via dev server (no global breakage).
- ⚠️ The admin/overview screens are behind auth — I couldn't screenshot them from the sandbox. Please eyeball them on `yarn dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)