### PR TITLE
fix(ui): polish admin/overview tables — readable names, balanced stats

### DIFF
--- a/src/features/admin/AdminPage.tsx
+++ b/src/features/admin/AdminPage.tsx
@@ -169,7 +169,7 @@ function AdminPanel() {
             </header>
 
             {/* --- STATS --- */}
-            <div className={`grid gap-2 sm:gap-3 ${isSuperAdmin ? 'grid-cols-2 sm:grid-cols-3' : 'grid-cols-2'}`}>
+            <div className={`grid gap-2 sm:gap-3 ${isSuperAdmin ? 'grid-cols-3' : 'grid-cols-2'}`}>
                 <StatCard icon={UsersIcon} label="Employees" value={empCount} accent="emerald" />
                 <StatCard icon={MapPinIcon} label="Locations" value={locCount} accent="blue" />
                 {isSuperAdmin && <StatCard icon={BuildingsIcon} label="Organizations" value={orgCount} accent="violet" />}

--- a/src/features/admin/components/AdminStateViews.tsx
+++ b/src/features/admin/components/AdminStateViews.tsx
@@ -27,7 +27,7 @@ export function StatCard({
                 </div>
                 <p className="text-xl sm:text-2xl font-black tracking-tight text-gray-900 dark:text-white leading-none">{value}</p>
             </div>
-            <p className="text-micro text-gray-400 mt-2 truncate">{label}</p>
+            <p className="text-micro tracking-tight text-gray-400 mt-2 truncate">{label}</p>
         </div>
     );
 }

--- a/src/features/admin/components/EmployeesList.tsx
+++ b/src/features/admin/components/EmployeesList.tsx
@@ -52,7 +52,7 @@ function AdminBadgeWithTooltip() {
 
 function RoleBadge({ role }: { role: Profile['role'] }) {
     return (
-        <span className={`inline-block px-1.5 py-1 text-micro rounded-md whitespace-nowrap ${getRoleBadgeColor(role.name)}`}>{role.name}</span>
+        <span className={`inline-block px-1.5 py-1 text-micro tracking-tight rounded-md whitespace-nowrap ${getRoleBadgeColor(role.name)}`}>{role.name}</span>
     );
 }
 
@@ -63,8 +63,8 @@ function EmployeeIdentity({ employee, isSelf }: { employee: Profile; isSelf: boo
                 {getFullInitials(employee.first_name, employee.last_name)}
             </div>
             <div className="min-w-0">
-                <div className="flex items-center gap-1.5">
-                    <h3 className="text-body-strong dark:text-white truncate">
+                <div className="flex items-center gap-1.5 min-w-0">
+                    <h3 className="text-body-strong dark:text-white truncate min-w-0">
                         {employee.first_name} {employee.last_name}
                     </h3>
                     {employee.role.rank >= RANK.ADMIN && <AdminBadgeWithTooltip />}
@@ -75,10 +75,6 @@ function EmployeeIdentity({ employee, isSelf }: { employee: Profile; isSelf: boo
                     )}
                 </div>
                 <p className="text-micro text-emerald-600 dark:text-emerald-400 truncate normal-case">@{employee.username}</p>
-                {/* Role lives in its own column on sm+; stacked here to stay compact on mobile. */}
-                <div className="sm:hidden mt-1">
-                    <RoleBadge role={employee.role} />
-                </div>
             </div>
         </div>
     );
@@ -100,13 +96,14 @@ export function EmployeesList({
     const manageable = (emp: Profile) => (currentUser ? canManageMember(currentUser, emp) : false);
 
     const columns: Column<Profile>[] = [
-        { key: 'employee', header: 'Employee', render: (emp) => <EmployeeIdentity employee={emp} isSelf={emp.id === currentUser?.id} />, className: 'max-w-[72vw] sm:max-w-none' },
-        { key: 'email', header: 'Email', hideOnMobile: true, render: (emp) => <span className="text-body text-gray-500 dark:text-gray-400 truncate">{emp.email}</span> },
-        { key: 'role', header: 'Role', align: 'right', hideOnMobile: true, render: (emp) => <RoleBadge role={emp.role} /> },
+        { key: 'employee', header: 'Employee', render: (emp) => <EmployeeIdentity employee={emp} isSelf={emp.id === currentUser?.id} /> },
+        { key: 'email', header: 'Email', width: 'w-64', hideOnMobile: true, className: 'truncate', render: (emp) => <span className="text-body text-gray-500 dark:text-gray-400">{emp.email}</span> },
+        { key: 'role', header: 'Role', align: 'right', width: 'w-24', render: (emp) => <RoleBadge role={emp.role} /> },
         {
             key: 'actions',
             header: '',
             align: 'right',
+            width: 'w-20',
             render: (emp) =>
                 manageable(emp) ? (
                     <div className="flex justify-end">

--- a/src/features/admin/components/LocationsList.tsx
+++ b/src/features/admin/components/LocationsList.tsx
@@ -38,11 +38,11 @@ export function LocationsList({
     onDelete: (loc: LocationRow) => void;
 }) {
     const columns: Column<LocationRow>[] = [
-        { key: 'loc', header: 'Location', render: (loc) => <LocationIdentity loc={loc} />, className: 'max-w-[70vw] sm:max-w-none' },
-        { key: 'org', header: 'Organization', hideOnMobile: true, render: (loc) => <span className="text-body text-gray-500 dark:text-gray-400 truncate">{loc.organizationName}</span> },
-        { key: 'id', header: 'ID', align: 'right', hideOnMobile: true, render: (loc) => <span className="text-micro text-gray-400 normal-case whitespace-nowrap">{loc.id.slice(0, 8)}</span> },
+        { key: 'loc', header: 'Location', render: (loc) => <LocationIdentity loc={loc} /> },
+        { key: 'org', header: 'Organization', width: 'w-44', hideOnMobile: true, className: 'truncate', render: (loc) => <span className="text-body text-gray-500 dark:text-gray-400">{loc.organizationName}</span> },
+        { key: 'id', header: 'ID', align: 'right', width: 'w-20', hideOnMobile: true, render: (loc) => <span className="text-micro text-gray-400 normal-case whitespace-nowrap">{loc.id.slice(0, 8)}</span> },
         ...(canManage
-            ? [{ key: 'actions', header: '', align: 'right' as const, render: (loc: LocationRow) => <div className="flex justify-end"><ActionButtons onEdit={() => onEdit(loc)} onDelete={() => onDelete(loc)} /></div> }]
+            ? [{ key: 'actions', header: '', align: 'right' as const, width: 'w-20', render: (loc: LocationRow) => <div className="flex justify-end"><ActionButtons onEdit={() => onEdit(loc)} onDelete={() => onDelete(loc)} /></div> }]
             : []),
     ];
 

--- a/src/features/admin/components/OrganizationsList.tsx
+++ b/src/features/admin/components/OrganizationsList.tsx
@@ -13,10 +13,6 @@ function OrgIdentity({ org }: { org: Organization }) {
             <div className="min-w-0">
                 <h3 className="text-body-strong dark:text-white truncate">{org.name}</h3>
                 <p className="text-micro text-gray-400 truncate normal-case">{org.slug}</p>
-                {/* Counts have their own columns on sm+; stacked here to stay compact on mobile. */}
-                <p className="sm:hidden text-micro text-gray-400 mt-1">
-                    {org.locations.length} locs · {org.profiles.length} users
-                </p>
             </div>
         </div>
     );
@@ -34,10 +30,10 @@ export function OrganizationsList({
     onDelete: (org: Organization) => void;
 }) {
     const columns: Column<Organization>[] = [
-        { key: 'org', header: 'Organization', render: (org) => <OrgIdentity org={org} />, className: 'max-w-[72vw] sm:max-w-none' },
-        { key: 'locs', header: 'Locs', align: 'right', hideOnMobile: true, render: (org) => <span className="text-metric-sm dark:text-white">{org.locations.length}</span> },
-        { key: 'users', header: 'Users', align: 'right', hideOnMobile: true, render: (org) => <span className="text-metric-sm dark:text-white">{org.profiles.length}</span> },
-        { key: 'actions', header: '', align: 'right', render: (org) => <div className="flex justify-end"><ActionButtons onEdit={() => onEdit(org)} onDelete={() => onDelete(org)} /></div> },
+        { key: 'org', header: 'Organization', render: (org) => <OrgIdentity org={org} /> },
+        { key: 'locs', header: 'Locs', align: 'right', width: 'w-20', hideOnMobile: true, render: (org) => <span className="text-metric-sm dark:text-white">{org.locations.length}</span> },
+        { key: 'users', header: 'Users', align: 'right', width: 'w-16 sm:w-20', render: (org) => <span className="text-metric-sm dark:text-white">{org.profiles.length}</span> },
+        { key: 'actions', header: '', align: 'right', width: 'w-20', render: (org) => <div className="flex justify-end"><ActionButtons onEdit={() => onEdit(org)} onDelete={() => onDelete(org)} /></div> },
     ];
 
     return (

--- a/src/features/shifts/OverviewPage.tsx
+++ b/src/features/shifts/OverviewPage.tsx
@@ -213,6 +213,7 @@ export default function OverviewPage() {
     {
       key: 'date',
       header: 'Date',
+      width: 'w-16 sm:w-24',
       className: 'whitespace-nowrap',
       footer: <span className="text-label text-gray-400">Total</span>,
       render: (shift) => {
@@ -230,7 +231,7 @@ export default function OverviewPage() {
     {
       key: 'location',
       header: 'Location & Time',
-      className: 'max-w-[46vw] sm:max-w-none',
+      className: 'w-full',
       // On mobile the Gross/Break columns are hidden to fit; surface them here.
       footer: (
         <span className="sm:hidden text-caption text-gray-500 dark:text-gray-400 tabular-nums">
@@ -255,6 +256,7 @@ export default function OverviewPage() {
       key: 'gross',
       header: 'Gross',
       align: 'right',
+      width: 'w-20',
       hideOnMobile: true,
       className: 'text-xs font-bold tabular-nums text-gray-600 dark:text-gray-300',
       footer: <span className="text-xs font-black tabular-nums dark:text-white">{fmtHours(stats.totalGross)}</span>,
@@ -264,6 +266,7 @@ export default function OverviewPage() {
       key: 'break',
       header: 'Break',
       align: 'right',
+      width: 'w-20',
       hideOnMobile: true,
       className: 'text-xs font-bold tabular-nums text-amber-500',
       footer: <span className="text-xs font-black tabular-nums text-amber-500">-{fmtHours(stats.totalBreak)}</span>,
@@ -276,6 +279,7 @@ export default function OverviewPage() {
       key: 'net',
       header: 'Net',
       align: 'right',
+      width: 'w-16 sm:w-20',
       footer: <span className="text-xs font-black tabular-nums text-emerald-600 dark:text-emerald-400">{fmtHours(stats.totalHours)}</span>,
       render: (shift) => {
         const ongoing = !shift.ended_at;

--- a/src/shared/components/DataTable.tsx
+++ b/src/shared/components/DataTable.tsx
@@ -4,9 +4,11 @@ import type { ReactNode } from 'react';
  * A single column definition for {@link DataTable}.
  *
  * The table renders as ONE real `<table>` on every breakpoint (no separate
- * mobile card layout) — compact on phones, roomier on `sm+`. Columns that are
- * secondary on small screens can opt out with {@link Column.hideOnMobile}; the
- * container also scrolls horizontally as a safety net so nothing ever clips.
+ * mobile card layout) — compact on phones, roomier on `sm+`. Layout is
+ * `table-fixed`: give the secondary columns a fixed {@link Column.width} and
+ * leave exactly one (the primary/identity column) without a width so it absorbs
+ * the remaining space and truncates. Columns can drop off small screens with
+ * {@link Column.hideOnMobile}.
  */
 export interface Column<T> {
   /** Stable identifier for the column (used as React key). */
@@ -17,6 +19,8 @@ export interface Column<T> {
   render: (row: T) => ReactNode;
   /** Horizontal alignment of the cell + header. Defaults to `left`. */
   align?: 'left' | 'right' | 'center';
+  /** Fixed column width (Tailwind class, e.g. `w-20`). Omit on the one flexible column. */
+  width?: string;
   /** Extra classes applied to the `<td>`. */
   className?: string;
   /** Extra classes applied to the `<th>`. */
@@ -51,10 +55,11 @@ const cellPad = 'px-2 py-2.5 sm:px-4 sm:py-3';
 const mobileHidden = 'hidden sm:table-cell';
 
 /**
- * Responsive, generic data table. A single `<table>` on all breakpoints —
- * compact and monolithic — sharing one look across Overview and the admin
- * panel. Centralizes the table chrome (rounded container, header, dividers,
- * hover, footer, loading/empty states) so feature surfaces only declare columns.
+ * Responsive, generic data table. A single `table-fixed` `<table>` that always
+ * fits its container (never scrolls sideways) — compact and monolithic — shared
+ * across Overview and the admin panel. Centralizes the table chrome (rounded
+ * container, header, dividers, hover, footer, loading/empty states) so feature
+ * surfaces only declare columns.
  */
 export function DataTable<T>({
   columns,
@@ -72,62 +77,60 @@ export function DataTable<T>({
 
   return (
     <div className="bg-white dark:bg-gray-900/40 rounded-2xl sm:rounded-3xl border border-gray-100 dark:border-gray-800 overflow-hidden shadow-sm">
-      <div className="overflow-x-auto">
-        <table className="w-full text-left border-collapse">
-          <thead>
-            <tr className="border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/30">
+      <table className="w-full table-fixed text-left border-collapse">
+        <thead>
+          <tr className="border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/30">
+            {columns.map((col) => (
+              <th
+                key={col.key}
+                className={`${cellPad} text-label text-gray-400 truncate ${ALIGN[col.align ?? 'left']} ${
+                  col.width ?? ''
+                } ${col.hideOnMobile ? mobileHidden : ''} ${col.headerClassName ?? ''}`}
+              >
+                {col.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-50 dark:divide-gray-800/50">
+          {rows.map((row) => (
+            <tr
+              key={rowKey(row)}
+              onClick={onRowClick ? () => onRowClick(row) : undefined}
+              className={`transition-colors hover:bg-gray-50/80 dark:hover:bg-gray-800/20 ${
+                onRowClick ? 'cursor-pointer' : ''
+              }`}
+            >
               {columns.map((col) => (
-                <th
+                <td
                   key={col.key}
-                  className={`${cellPad} text-label text-gray-400 whitespace-nowrap ${ALIGN[col.align ?? 'left']} ${
+                  className={`${cellPad} ${ALIGN[col.align ?? 'left']} ${col.width ?? ''} ${
                     col.hideOnMobile ? mobileHidden : ''
-                  } ${col.headerClassName ?? ''}`}
+                  } ${col.className ?? ''}`}
                 >
-                  {col.header}
-                </th>
+                  {col.render(row)}
+                </td>
               ))}
             </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-50 dark:divide-gray-800/50">
-            {rows.map((row) => (
-              <tr
-                key={rowKey(row)}
-                onClick={onRowClick ? () => onRowClick(row) : undefined}
-                className={`transition-colors hover:bg-gray-50/80 dark:hover:bg-gray-800/20 ${
-                  onRowClick ? 'cursor-pointer' : ''
-                }`}
-              >
-                {columns.map((col) => (
-                  <td
-                    key={col.key}
-                    className={`${cellPad} ${ALIGN[col.align ?? 'left']} ${col.hideOnMobile ? mobileHidden : ''} ${
-                      col.className ?? ''
-                    }`}
-                  >
-                    {col.render(row)}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-          {hasFooter && (
-            <tfoot>
-              <tr className="border-t border-gray-100 dark:border-gray-800 bg-gray-50/60 dark:bg-gray-800/40">
-                {columns.map((col) => (
-                  <td
-                    key={col.key}
-                    className={`${cellPad} whitespace-nowrap ${ALIGN[col.align ?? 'left']} ${
-                      col.hideOnMobile ? mobileHidden : ''
-                    }`}
-                  >
-                    {col.footer}
-                  </td>
-                ))}
-              </tr>
-            </tfoot>
-          )}
-        </table>
-      </div>
+          ))}
+        </tbody>
+        {hasFooter && (
+          <tfoot>
+            <tr className="border-t border-gray-100 dark:border-gray-800 bg-gray-50/60 dark:bg-gray-800/40">
+              {columns.map((col) => (
+                <td
+                  key={col.key}
+                  className={`${cellPad} truncate ${ALIGN[col.align ?? 'left']} ${col.width ?? ''} ${
+                    col.hideOnMobile ? mobileHidden : ''
+                  }`}
+                >
+                  {col.footer}
+                </td>
+              ))}
+            </tr>
+          </tfoot>
+        )}
+      </table>
     </div>
   );
 }


### PR DESCRIPTION
Follow-up to the monolithic-tables work after mobile review feedback (rows looked clumsy with the role badge dumped under the name; stat cards weren't centered).

## Changes
- **DataTable**: switched to `table-fixed` — the identity column absorbs the remaining width and truncates cleanly; secondary columns get fixed widths. No sideways scroll, no clipped actions, deterministic on mobile and desktop.
- **Employees**: role is a compact right-aligned column again (not stacked under the name). Fixed a missing `min-w-0` on the name+badges flex so short names like 'Admin' render fully and only genuinely long names truncate.
- **Organizations**: Locs/Users back as right-aligned columns (removed the stacked caption).
- **StatCard**: tighter label tracking so EMPLOYEES/LOCATIONS/ORGANIZATIONS fit on one line; admin stats are a balanced 3-up row (no orphan card).

## Verification
Rendered all tables with mock data in a temporary harness and screenshotted at **375px** and **desktop**: names readable, badges/actions aligned, **zero horizontal overflow** (measured `scrollWidth === clientWidth`). Harness removed before commit.
`typecheck` ✓ · `lint` ✓ (0 errors) · `test` ✓ 26/26 · `build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)