### PR TITLE
fix(ui): unified role badges + balanced desktop admin tables

### DIFF
--- a/src/features/admin/components/EmployeesList.tsx
+++ b/src/features/admin/components/EmployeesList.tsx
@@ -97,8 +97,8 @@ export function EmployeesList({
 
     const columns: Column<Profile>[] = [
         { key: 'employee', header: 'Employee', render: (emp) => <EmployeeIdentity employee={emp} isSelf={emp.id === currentUser?.id} /> },
-        { key: 'email', header: 'Email', width: 'w-64', hideOnMobile: true, className: 'truncate', render: (emp) => <span className="text-body text-gray-500 dark:text-gray-400">{emp.email}</span> },
-        { key: 'role', header: 'Role', align: 'right', width: 'w-24', render: (emp) => <RoleBadge role={emp.role} /> },
+        { key: 'email', header: 'Email', hideOnMobile: true, className: 'truncate', render: (emp) => <span className="text-body text-gray-500 dark:text-gray-400">{emp.email}</span> },
+        { key: 'role', header: 'Role', align: 'right', width: 'w-24 sm:w-32', render: (emp) => <RoleBadge role={emp.role} /> },
         {
             key: 'actions',
             header: '',

--- a/src/features/admin/components/LocationsList.tsx
+++ b/src/features/admin/components/LocationsList.tsx
@@ -39,7 +39,7 @@ export function LocationsList({
 }) {
     const columns: Column<LocationRow>[] = [
         { key: 'loc', header: 'Location', render: (loc) => <LocationIdentity loc={loc} /> },
-        { key: 'org', header: 'Organization', width: 'w-44', hideOnMobile: true, className: 'truncate', render: (loc) => <span className="text-body text-gray-500 dark:text-gray-400">{loc.organizationName}</span> },
+        { key: 'org', header: 'Organization', hideOnMobile: true, className: 'truncate', render: (loc) => <span className="text-body text-gray-500 dark:text-gray-400">{loc.organizationName}</span> },
         { key: 'id', header: 'ID', align: 'right', width: 'w-20', hideOnMobile: true, render: (loc) => <span className="text-micro text-gray-400 normal-case whitespace-nowrap">{loc.id.slice(0, 8)}</span> },
         ...(canManage
             ? [{ key: 'actions', header: '', align: 'right' as const, width: 'w-20', render: (loc: LocationRow) => <div className="flex justify-end"><ActionButtons onEdit={() => onEdit(loc)} onDelete={() => onDelete(loc)} /></div> }]

--- a/src/shared/utils/roleColors.ts
+++ b/src/shared/utils/roleColors.ts
@@ -1,12 +1,18 @@
+// One consistent badge treatment for every role — a soft tinted pill (light
+// surface + colored text in light mode, translucent + bright text in dark).
+// Only the hue changes per rank, so the set reads as a unified palette.
+// NOTE: keep these as full literal class strings so Tailwind can detect them.
 const ROLE_COLORS: Record<string, string> = {
-    Superadmin: 'bg-red-900 text-white',
-    'Head Admin': 'bg-amber-500 text-white',
-    Admin: 'bg-red-500 text-white',
-    Manager: 'bg-purple-600 text-white',
-    Supervisor: 'bg-blue-500 text-white',
-    Employee: 'bg-lime-400 text-white',
+    Superadmin: 'bg-rose-100 text-rose-700 dark:bg-rose-500/15 dark:text-rose-300',
+    'Head Admin': 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300',
+    Admin: 'bg-orange-100 text-orange-700 dark:bg-orange-500/15 dark:text-orange-300',
+    Manager: 'bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-300',
+    Supervisor: 'bg-sky-100 text-sky-700 dark:bg-sky-500/15 dark:text-sky-300',
+    Employee: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300',
 };
 
+const FALLBACK = 'bg-gray-100 text-gray-600 dark:bg-gray-500/15 dark:text-gray-300';
+
 export function getRoleBadgeColor(role: string): string {
-    return ROLE_COLORS[role] || 'bg-red-100 text-red-700';
+    return ROLE_COLORS[role] || FALLBACK;
 }


### PR DESCRIPTION
Desktop admin-panel polish (from screenshot review):

- **Role badges** — one consistent soft-tinted pill style, hue per rank (rose/amber/orange/violet/sky/emerald + gray fallback), light & dark variants. Replaces the clashing solid `lime-400`/`red-900`/`amber-500` look with a unified palette.
- **Balanced columns** — Email (Employees) and Organization (Locations) are now flexible columns, so the identity column stops absorbing all slack and the huge gap between name and email is gone on wide screens.
- **Edit button no longer overlaps the role badge** — role column widened (`w-24 sm:w-32`) so the badge stays inside its cell.

Verified with a temporary mock harness at desktop and 375px: unified badges, balanced layout, edit/delete spaced, **zero horizontal overflow**. Harness removed before commit. typecheck/lint/test/build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)