### PR TITLE
fix(ui): widen admin action column so edit button stops overlapping

### DIFF
--- a/src/features/admin/components/EmployeesList.tsx
+++ b/src/features/admin/components/EmployeesList.tsx
@@ -103,7 +103,7 @@ export function EmployeesList({
             key: 'actions',
             header: '',
             align: 'right',
-            width: 'w-20',
+            width: 'w-20 sm:w-28',
             render: (emp) =>
                 manageable(emp) ? (
                     <div className="flex justify-end">

--- a/src/features/admin/components/LocationsList.tsx
+++ b/src/features/admin/components/LocationsList.tsx
@@ -40,9 +40,9 @@ export function LocationsList({
     const columns: Column<LocationRow>[] = [
         { key: 'loc', header: 'Location', render: (loc) => <LocationIdentity loc={loc} /> },
         { key: 'org', header: 'Organization', hideOnMobile: true, className: 'truncate', render: (loc) => <span className="text-body text-gray-500 dark:text-gray-400">{loc.organizationName}</span> },
-        { key: 'id', header: 'ID', align: 'right', width: 'w-20', hideOnMobile: true, render: (loc) => <span className="text-micro text-gray-400 normal-case whitespace-nowrap">{loc.id.slice(0, 8)}</span> },
+        { key: 'id', header: 'ID', align: 'right', width: 'w-28', hideOnMobile: true, render: (loc) => <span className="text-micro tracking-normal text-gray-400 normal-case whitespace-nowrap">{loc.id.slice(0, 8)}</span> },
         ...(canManage
-            ? [{ key: 'actions', header: '', align: 'right' as const, width: 'w-20', render: (loc: LocationRow) => <div className="flex justify-end"><ActionButtons onEdit={() => onEdit(loc)} onDelete={() => onDelete(loc)} /></div> }]
+            ? [{ key: 'actions', header: '', align: 'right' as const, width: 'w-20 sm:w-28', render: (loc: LocationRow) => <div className="flex justify-end"><ActionButtons onEdit={() => onEdit(loc)} onDelete={() => onDelete(loc)} /></div> }]
             : []),
     ];
 

--- a/src/features/admin/components/OrganizationsList.tsx
+++ b/src/features/admin/components/OrganizationsList.tsx
@@ -33,7 +33,7 @@ export function OrganizationsList({
         { key: 'org', header: 'Organization', render: (org) => <OrgIdentity org={org} /> },
         { key: 'locs', header: 'Locs', align: 'right', width: 'w-20', hideOnMobile: true, render: (org) => <span className="text-metric-sm dark:text-white">{org.locations.length}</span> },
         { key: 'users', header: 'Users', align: 'right', width: 'w-16 sm:w-20', render: (org) => <span className="text-metric-sm dark:text-white">{org.profiles.length}</span> },
-        { key: 'actions', header: '', align: 'right', width: 'w-20', render: (org) => <div className="flex justify-end"><ActionButtons onEdit={() => onEdit(org)} onDelete={() => onDelete(org)} /></div> },
+        { key: 'actions', header: '', align: 'right', width: 'w-20 sm:w-28', render: (org) => <div className="flex justify-end"><ActionButtons onEdit={() => onEdit(org)} onDelete={() => onDelete(org)} /></div> },
     ];
 
     return (


### PR DESCRIPTION
The previous polish fixed only the Employees role overlap. Root cause was systemic: the **actions column (`w-20`) is too narrow for two `p-2.5` icon buttons on desktop**, so the edit button overflowed left onto the neighbouring cell — the pencil landed on the Locations **ID** and the Organizations **count**.

- Actions column widened to `w-20 sm:w-28` in Employees / Locations / Organizations.
- Locations **ID** column given room (`w-28`, normal tracking) so the 8-char hash no longer crowds the actions.

Verified in a temporary mock harness at desktop and 375px: edit/delete clearly separated from the preceding column, **zero horizontal overflow**. Harness removed before commit. typecheck/lint/test/build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)