### PR TITLE
fix(ui): drop empty actions column for read-only admin viewers

### DIFF
--- a/src/features/admin/components/EmployeesList.tsx
+++ b/src/features/admin/components/EmployeesList.tsx
@@ -94,23 +94,31 @@ export function EmployeesList({
     onDelete: (emp: Profile) => void;
 }) {
     const manageable = (emp: Profile) => (currentUser ? canManageMember(currentUser, emp) : false);
+    // Read-only viewers (e.g. Manager) can't manage anyone — drop the actions
+    // column entirely so the Role badge sits flush right instead of leaving an
+    // empty gutter.
+    const anyManageable = items.some(manageable);
 
     const columns: Column<Profile>[] = [
         { key: 'employee', header: 'Employee', render: (emp) => <EmployeeIdentity employee={emp} isSelf={emp.id === currentUser?.id} /> },
         { key: 'email', header: 'Email', hideOnMobile: true, className: 'truncate', render: (emp) => <span className="text-body text-gray-500 dark:text-gray-400">{emp.email}</span> },
         { key: 'role', header: 'Role', align: 'right', width: 'w-24 sm:w-32', render: (emp) => <RoleBadge role={emp.role} /> },
-        {
-            key: 'actions',
-            header: '',
-            align: 'right',
-            width: 'w-20 sm:w-28',
-            render: (emp) =>
-                manageable(emp) ? (
-                    <div className="flex justify-end">
-                        <ActionButtons onEdit={() => onEdit(emp)} onDelete={() => onDelete(emp)} />
-                    </div>
-                ) : null,
-        },
+        ...(anyManageable
+            ? [
+                  {
+                      key: 'actions',
+                      header: '',
+                      align: 'right' as const,
+                      width: 'w-20 sm:w-28',
+                      render: (emp: Profile) =>
+                          manageable(emp) ? (
+                              <div className="flex justify-end">
+                                  <ActionButtons onEdit={() => onEdit(emp)} onDelete={() => onDelete(emp)} />
+                              </div>
+                          ) : null,
+                  },
+              ]
+            : []),
     ];
 
     return (


### PR DESCRIPTION
A **Manager** can open the admin panel but can't manage anyone (read-only). The Employees table still rendered the actions column with `null` cells for every row, leaving a dead gutter on the right and pushing the Role badge away from the edge — looked broken on desktop and mobile.

Fix: include the actions column only when at least one row is manageable; otherwise **Role** is the last column and sits flush right. Locations already dropped its actions column when `canManage` is false, so it's consistent now.

Verified in a temp harness as a Manager (read-only) at desktop and 375px: Role badge flush right, no empty gutter, tables look intentional. Harness removed before commit. typecheck/lint/test/build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)