### PR TITLE
fix(ui): stop duplicating organization in Locations table on desktop

### DIFF
--- a/src/features/admin/components/LocationsList.tsx
+++ b/src/features/admin/components/LocationsList.tsx
@@ -18,7 +18,8 @@ function LocationIdentity({ loc }: { loc: LocationRow }) {
             </div>
             <div className="min-w-0">
                 <h3 className="text-body-strong dark:text-white truncate">{loc.name}</h3>
-                <p className="text-micro text-gray-400 truncate">{loc.organizationName}</p>
+                {/* Org has its own column on sm+; show it here only on mobile (where that column is hidden). */}
+                <p className="sm:hidden text-micro text-gray-400 truncate">{loc.organizationName}</p>
             </div>
         </div>
     );


### PR DESCRIPTION
On desktop the Locations table showed the organization **twice** — as a subtitle under the location name *and* in the dedicated Organization column. The subtitle is now `sm:hidden`: desktop relies on the Organization column, mobile keeps the subtitle (where that column is hidden).

Verified in a temp harness: desktop shows org only in its column, mobile shows it as the subtitle. Harness removed before commit. typecheck/lint/test/build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)