### PR TITLE
feat(invite): pick your own username + collision-safe default

### DIFF
--- a/src/features/auth/AcceptInvitePage.tsx
+++ b/src/features/auth/AcceptInvitePage.tsx
@@ -5,6 +5,7 @@ import {
     BuildingsIcon,
     IdentificationBadgeIcon,
     CheckCircleIcon,
+    AtIcon,
     LockIcon,
     EyeIcon,
     EyeSlashIcon,
@@ -25,6 +26,9 @@ import { getRoleBadgeColor } from '@shared/utils/roleColors';
  */
 
 type Status = 'loading' | 'ready' | 'invalid';
+
+// Mirrors the rule enforced in Settings + the DB unique_username constraint.
+const USERNAME_RE = /^[a-z0-9._-]{3,30}$/;
 
 interface InviteInfo {
     email: string;
@@ -72,6 +76,7 @@ export function AcceptInvitePage() {
     const navigate = useNavigate();
     const [status, setStatus] = useState<Status>('loading');
     const [info, setInfo] = useState<InviteInfo | null>(null);
+    const [username, setUsername] = useState('');
     const [firstName, setFirstName] = useState('');
     const [lastName, setLastName] = useState('');
     const [password, setPassword] = useState('');
@@ -92,6 +97,7 @@ export function AcceptInvitePage() {
                 .single();
 
             setInfo({ email: profile.email, role: profile.role.name, org: org?.name ?? '—' });
+            setUsername(profile.username ?? '');
             setFirstName(profile.first_name ?? '');
             setLastName(profile.last_name ?? '');
             setStatus('ready');
@@ -143,6 +149,10 @@ export function AcceptInvitePage() {
 
     const handleSubmit = async (e: SyntheticEvent) => {
         e.preventDefault();
+        const uname = username.trim().toLowerCase();
+        if (!USERNAME_RE.test(uname)) {
+            return setError('Username must be 3–30 characters: lowercase letters, numbers, dot, underscore or hyphen.');
+        }
         if (password.length < 6) return setError('Password must be at least 6 characters.');
         if (password !== confirm) return setError('Passwords do not match.');
 
@@ -155,13 +165,26 @@ export function AcceptInvitePage() {
             });
             if (updateError) throw updateError;
 
-            // Persist names to the profile row as well.
+            // Persist the chosen username + names to the profile row.
             const { data: { user } } = await supabase.auth.getUser();
             if (user) {
-                await supabase
+                const { error: profileError } = await supabase
                     .from('profiles')
-                    .update({ first_name: firstName.trim() || null, last_name: lastName.trim() || null })
+                    .update({
+                        username: uname,
+                        first_name: firstName.trim() || null,
+                        last_name: lastName.trim() || null,
+                    })
                     .eq('id', user.id);
+                if (profileError) {
+                    setError(
+                        profileError.code === '23505'
+                            ? 'That username is already taken. Please choose another.'
+                            : profileError.message || 'Could not save your changes.',
+                    );
+                    setBusy(false);
+                    return;
+                }
             }
 
             // Full reload so AuthProvider re-initialises with the now-complete session.
@@ -251,7 +274,25 @@ export function AcceptInvitePage() {
                     <form onSubmit={handleSubmit} className="p-6 space-y-4">
                         <div>
                             <h2 className="text-heading text-gray-900 dark:text-white">Set up your account</h2>
-                            <p className="text-small text-gray-400 mt-0.5">Choose a password to accept the invitation.</p>
+                            <p className="text-small text-gray-400 mt-0.5">Pick a username and password to accept the invitation.</p>
+                        </div>
+
+                        <div>
+                            <label htmlFor="username" className="text-micro text-gray-400 ml-1">Username</label>
+                            <div className="relative mt-1.5">
+                                <AtIcon weight="bold" className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                                <input
+                                    id="username"
+                                    value={username}
+                                    onChange={(e) => setUsername(e.target.value)}
+                                    placeholder="username"
+                                    autoCapitalize="none"
+                                    autoCorrect="off"
+                                    spellCheck={false}
+                                    className={`${INPUT} pl-10 pr-3.5`}
+                                />
+                            </div>
+                            <p className="text-caption text-gray-400 mt-1.5 ml-1">Used to sign in instead of your email. Must be unique.</p>
                         </div>
 
                         <div className="grid grid-cols-2 gap-3">

--- a/supabase/migrations/20260619120000_username_collision_safe.sql
+++ b/supabase/migrations/20260619120000_username_collision_safe.sql
@@ -1,0 +1,65 @@
+-- =============================================================================
+-- COLLISION-SAFE USERNAME GENERATION
+-- -----------------------------------------------------------------------------
+-- Email prefixes collide: jondow@gmail.com, jondow@yahoo.com, jondow@example.com
+-- all resolve to "jondow". Since profiles.username is UNIQUE (unique_username),
+-- the second such invite previously failed inside handle_new_user on the unique
+-- violation — blocking the invite entirely.
+--
+-- Append a numeric suffix until the name is free (jondow, jondow1, jondow2, …).
+-- Invitees can still pick a nicer username afterwards on the accept-invite page.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_org_id uuid;
+  v_role text;
+  v_base text;
+  v_username text;
+  v_suffix int := 0;
+BEGIN
+  -- Organization: prefer invite metadata, else the seeded default organization.
+  v_org_id := NULLIF(new.raw_user_meta_data->>'organization_id', '')::uuid;
+  IF v_org_id IS NULL THEN
+    SELECT id INTO v_org_id FROM public.organizations WHERE slug = 'default-org';
+  END IF;
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'No organization for new user: provide organization_id metadata or seed a "default-org".';
+  END IF;
+
+  -- Role: prefer invite metadata, else Employee. (FK to roles enforces validity.)
+  v_role := COALESCE(NULLIF(new.raw_user_meta_data->>'role', ''), 'Employee');
+
+  -- Base username: invite metadata -> email prefix -> random.
+  v_base := COALESCE(
+    NULLIF(new.raw_user_meta_data->>'username', ''),
+    NULLIF(split_part(new.email, '@', 1), ''),
+    'user_' || substr(md5(random()::text), 1, 8)
+  );
+
+  -- Ensure uniqueness so a duplicate prefix never blocks provisioning.
+  v_username := v_base;
+  WHILE EXISTS (SELECT 1 FROM public.profiles WHERE username = v_username) LOOP
+    v_suffix := v_suffix + 1;
+    v_username := v_base || v_suffix;
+  END LOOP;
+
+  INSERT INTO public.profiles (id, username, role, email, organization_id, first_name, last_name)
+  VALUES (
+    new.id,
+    v_username,
+    v_role,
+    new.email,
+    v_org_id,
+    NULLIF(new.raw_user_meta_data->>'first_name', ''),
+    NULLIF(new.raw_user_meta_data->>'last_name', '')
+  );
+
+  RETURN new;
+END;
+$$;


### PR DESCRIPTION
Two related changes for the invite flow.

**Collision-safe username (DB)** — `handle_new_user` now appends a numeric suffix until the name is free (`jondow`, `jondow1`, `jondow2`…). Email prefixes collide (`jondow@gmail.com` / `@yahoo.com` / `@example.com` → `jondow`) and `profiles.username` is UNIQUE, so the 2nd such **invite previously failed** on `unique_username`. Migration already applied to **preprod + prod** (verified `pg_get_functiondef` contains the dedup loop).

**Pick your own username (accept-invite)** — adds a Username field, prefilled with the assigned default (so the invitee isn't stuck with the email prefix). Validates format (`^[a-z0-9._-]{3,30}$`, lowercased) and surfaces a friendly 'already taken' message on the `23505` unique violation.

Verified on the live preview (ready state): username field prefilled with the de-duped default, consistent branded-glass styling. typecheck/lint/test/build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)