### PR TITLE
fix(shifts): restore location change on prod + live location updates

### DIFF
--- a/src/features/shifts/hooks/useRealtime.ts
+++ b/src/features/shifts/hooks/useRealtime.ts
@@ -128,6 +128,20 @@ export function useRealtime({
           }
         }
       )
+      // 3. Locations: when an admin adds / renames / removes a location, refetch
+      //    so it appears in the dashboard picker live (no reload needed).
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'locations',
+          filter: `organization_id=eq.${user.organization_id}`,
+        },
+        () => {
+          refreshData();
+        },
+      )
       .subscribe();
 
     // CLEANUP: Close connections when component is unmounted.

--- a/supabase/migrations/20260619130000_shifts_prev_location_and_realtime.sql
+++ b/supabase/migrations/20260619130000_shifts_prev_location_and_realtime.sql
@@ -1,0 +1,37 @@
+-- =============================================================================
+-- FIX: shift location change + live locations
+-- -----------------------------------------------------------------------------
+-- 1. The prod `shifts` table was created from an older schema and is missing the
+--    `previous_location_id` column the base dump defines. changeShiftLocation
+--    writes to it, so location changes failed with PGRST204 ("Could not find
+--    the 'previous_location_id' column"). Add it idempotently (+ FK).
+-- 2. Only `shifts` was in the `supabase_realtime` publication, so newly added
+--    locations didn't appear on other clients' dashboards in real time. Add
+--    `locations` to the publication.
+-- =============================================================================
+
+-- 1. previous_location_id ----------------------------------------------------
+ALTER TABLE public.shifts ADD COLUMN IF NOT EXISTS previous_location_id uuid;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'shifts_previous_location_id_fkey'
+  ) THEN
+    ALTER TABLE public.shifts
+      ADD CONSTRAINT shifts_previous_location_id_fkey
+      FOREIGN KEY (previous_location_id) REFERENCES public.locations(id);
+  END IF;
+END $$;
+
+-- 2. Realtime for locations --------------------------------------------------
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime' AND schemaname = 'public' AND tablename = 'locations'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.locations;
+  END IF;
+END $$;
+
+-- Refresh PostgREST's schema cache so the new column is immediately usable.
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Two issues reported from prod:

**Changing work location failed (PGRST204)** — prod's `shifts` table predates the `previous_location_id` column the base schema defines, so `changeShiftLocation` errored: *Could not find the 'previous_location_id' column of 'shifts' in the schema cache*. Migration adds the column + FK idempotently. Applied to **prod + preprod** and reloaded the PostgREST schema cache (verified the column now exists on prod).

**New locations didn't appear live** — only `shifts` was in the `supabase_realtime` publication. Added `locations` to it and subscribed to the table in `useRealtime` (refetches on insert/update/delete), so a location added in the admin panel shows up on dashboards without a reload.

(Head-admin editing was reported alongside these but is already working — RLS + frontend both allow rank ≥ 30 admins to edit lower members; left untouched.)

typecheck/lint/test/build ✓. DB changes already applied to both projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)