### PR TITLE
fix(realtime): deliver location DELETE events (REPLICA IDENTITY FULL)

### DIFF
--- a/supabase/migrations/20260619140000_locations_replica_identity_full.sql
+++ b/supabase/migrations/20260619140000_locations_replica_identity_full.sql
@@ -1,0 +1,12 @@
+-- =============================================================================
+-- FIX: live DELETE for locations
+-- -----------------------------------------------------------------------------
+-- The locations realtime subscription is filtered by organization_id. With the
+-- default REPLICA IDENTITY (primary key only), a DELETE's `old` record carries
+-- just the id — so `organization_id` is absent and the filter never matches,
+-- meaning deletes were silently dropped (adds/renames worked because INSERT/
+-- UPDATE carry the full new row). REPLICA IDENTITY FULL makes the old row carry
+-- every column, so filtered DELETE events are delivered. (shifts is already FULL.)
+-- =============================================================================
+
+ALTER TABLE public.locations REPLICA IDENTITY FULL;


### PR DESCRIPTION
Deleting a location didn't update dashboards live (adding/renaming did).

Cause: the `locations` realtime subscription filters on `organization_id`, but with the default replica identity a DELETE's old record only carries the **primary key** — `organization_id` is absent, so the filtered DELETE event is never delivered. (`shifts` was already `REPLICA IDENTITY FULL`, which is why shift deletes worked.)

Fix: `ALTER TABLE public.locations REPLICA IDENTITY FULL` — the old row now carries every column, so filtered DELETE events arrive and `useRealtime` refetches. Applied to **prod + preprod** (verified). No frontend change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)