### PR TITLE
feat(locations): archive instead of hard-delete (preserve shifts/history)

### DIFF
--- a/src/app/layout/HomePage.tsx
+++ b/src/app/layout/HomePage.tsx
@@ -21,6 +21,10 @@ export function HomePage() {
 
   if (!user) return null;
 
+  // Archived locations stay available for history-name resolution (Overview) but
+  // must not appear as places you can pick or clock in at.
+  const activeLocations = locations.filter((l) => !l.archived_at);
+
   return (
     <>
       {/* 1. CLOCK (Desktop Only) */}
@@ -39,14 +43,14 @@ export function HomePage() {
       {/* 4. MOBILE LOCATION PICKER */}
       <div className="md:hidden mb-6 -mx-3 px-3">
         <LocationSelection
-          locations={locations}
+          locations={activeLocations}
           selectedLocationId={selectedLocationId}
           onLocationSelect={handleLocationSelect}
         />
       </div>
 
       <div className="space-y-4">
-        {locations.map((location) => {
+        {activeLocations.map((location) => {
           const userFullName = `${user.first_name || ''} ${user.last_name || ''}`.trim() || user.username;
           const role = user.role.name
           // Find colleagues working in this specific location.

--- a/src/features/admin/AdminPage.tsx
+++ b/src/features/admin/AdminPage.tsx
@@ -84,12 +84,14 @@ function AdminPanel() {
     const locations = useMemo<LocationRow[]>(() => {
         const all =
             adminData?.flatMap((org) =>
-                org.locations.map((loc) => ({
-                    id: loc.id,
-                    name: loc.name,
-                    organization_id: loc.organization_id,
-                    organizationName: org.name,
-                })),
+                org.locations
+                    .filter((loc) => !loc.archived_at) // archived locations are hidden
+                    .map((loc) => ({
+                        id: loc.id,
+                        name: loc.name,
+                        organization_id: loc.organization_id,
+                        organizationName: org.name,
+                    })),
             ) ?? [];
         if (!query) return all;
         return all.filter((l) => `${l.name} ${l.organizationName}`.toLowerCase().includes(query));
@@ -125,7 +127,7 @@ function AdminPanel() {
     };
 
     const orgCount = adminData?.length ?? 0;
-    const locCount = adminData?.reduce((n, o) => n + o.locations.length, 0) ?? 0;
+    const locCount = adminData?.reduce((n, o) => n + o.locations.filter((l) => !l.archived_at).length, 0) ?? 0;
     const empCount = adminData?.reduce((n, o) => n + o.profiles.length, 0) ?? 0;
 
     // Capability flags drive what the current user can do (mirrors RLS).

--- a/src/features/admin/adminService.tsx
+++ b/src/features/admin/adminService.tsx
@@ -22,7 +22,7 @@ import { z } from 'zod';
 
 // Shared select used to hydrate the full organization tree (locations + members).
 const ORG_TREE_SELECT =
-    '*, locations(id, name, organization_id), profiles(id, role(name, is_admin, rank), email, username, first_name, last_name, organization_id)';
+    '*, locations(id, name, organization_id, archived_at), profiles(id, role(name, is_admin, rank), email, username, first_name, last_name, organization_id)';
 
 export interface EmployeeUpdate {
     first_name: string | null;
@@ -118,8 +118,17 @@ export const adminService = {
         if (error) throw error;
     },
 
+    /**
+     * "Deletes" a location by archiving it (soft delete). Hard-deleting would
+     * CASCADE-remove every shift there — wiping active shifts and payroll
+     * history. Archiving hides it from pickers/admin while keeping all history,
+     * and is what the realtime subscription propagates to dashboards.
+     */
     async deleteLocation(id: string): Promise<void> {
-        const { error } = await supabase.from('locations').delete().eq('id', id);
+        const { error } = await supabase
+            .from('locations')
+            .update({ archived_at: new Date().toISOString() })
+            .eq('id', id);
         if (error) throw error;
     },
 

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -43,7 +43,7 @@ export function Dashboard({ onLocationSelect }: DashboardProps) {
   const currentRoute = useLocation();
 
   const filteredLocations = locations.filter(loc =>
-    loc.name.toLowerCase().includes(searchQuery.toLowerCase())
+    !loc.archived_at && loc.name.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
   return (

--- a/src/features/locations/locationService.ts
+++ b/src/features/locations/locationService.ts
@@ -30,11 +30,13 @@ export const locationService = {
     // Validate that the array of locations matches our expected structure.
     const validated = z.array(LocationSchema).parse(data);
 
-    // Return them in a format the app likes.
+    // Return all (including archived) so historical shift names still resolve
+    // in Overview; pickers filter out archived locations at the display layer.
     return validated.map(l => ({
       id: l.id,
       name: l.name,
-      organization_id: l.organization_id
+      organization_id: l.organization_id,
+      archived_at: l.archived_at ?? null,
     }));
   }
 };

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -52,7 +52,8 @@ export const LocationSchema = z.object({
   id: z.string(), // Unique location ID
   name: z.string(), // Name of the restaurant/office
   organization_id: z.string().optional(),
-  organizationName: z.string().optional()
+  organizationName: z.string().optional(),
+  archived_at: z.string().nullable().optional(), // soft-delete: hidden from pickers, history kept
 });
 
 /**
@@ -66,7 +67,8 @@ export const OrganizationSchema = z.object({
     {
       id: z.string(),
       name: z.string(),
-      organization_id: z.string()
+      organization_id: z.string(),
+      archived_at: z.string().nullable().optional()
     }
   )),
   profiles: z.array(z.object({

--- a/supabase/migrations/20260619150000_locations_archived_at.sql
+++ b/supabase/migrations/20260619150000_locations_archived_at.sql
@@ -1,0 +1,11 @@
+-- =============================================================================
+-- SOFT-DELETE (ARCHIVE) FOR LOCATIONS
+-- -----------------------------------------------------------------------------
+-- Hard-deleting a location CASCADE-removes every shift there (shifts.location_id
+-- ON DELETE CASCADE) — wiping active shifts and payroll/Overview history. Instead
+-- the admin "delete" now archives: set archived_at. Archived locations are hidden
+-- from pickers + the admin list but keep all history (names still resolve in
+-- Overview). The realtime UPDATE on this column propagates the change live.
+-- =============================================================================
+
+ALTER TABLE public.locations ADD COLUMN IF NOT EXISTS archived_at timestamptz;


### PR DESCRIPTION
Answers 'what happens if I delete a location with people on it' — and fixes the dangerous current behavior.

**Before:** `shifts.location_id` is `ON DELETE CASCADE`, so deleting a location silently removed **all** shifts there (active workers kicked off + payroll/Overview history wiped). And if the location was recorded as someone's `previous_location_id`, the delete errored with an FK violation. Both bad.

**Now:** the admin 'delete' **archives** the location (`locations.archived_at`):
- Hidden from pickers (Home, Dashboard sidebar), the admin list, and the Locations stat.
- Kept in `getLocations` so historical shift names still resolve in Overview.
- Active shifts + all history untouched.
- Archiving is an UPDATE, so the realtime subscription propagates it live (location vanishes from dashboards without reload).

Migration adds `archived_at` to **prod + preprod** (applied + schema cache reloaded). typecheck/lint/test/build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)