### PR TITLE
feat(admin): let Superadmin move a location to another organization

### DIFF
--- a/src/features/admin/AdminContext.tsx
+++ b/src/features/admin/AdminContext.tsx
@@ -29,7 +29,7 @@ interface AdminContextType {
 
     // Locations
     createLocation: (values: { organization_id: string; name: string }) => Promise<void>;
-    updateLocation: (id: string, name: string) => Promise<void>;
+    updateLocation: (id: string, values: { name: string; organization_id?: string }) => Promise<void>;
     deleteLocation: (id: string) => Promise<void>;
 
     // Employees
@@ -109,7 +109,8 @@ export function AdminProvider({ children }: { children: ReactNode }) {
         [run],
     );
     const updateLocation = useCallback(
-        (id: string, name: string) => run(() => adminService.updateLocation(id, name)),
+        (id: string, values: { name: string; organization_id?: string }) =>
+            run(() => adminService.updateLocation(id, values)),
         [run],
     );
     const deleteLocation = useCallback(

--- a/src/features/admin/adminService.tsx
+++ b/src/features/admin/adminService.tsx
@@ -113,8 +113,10 @@ export const adminService = {
         if (error) throw error;
     },
 
-    async updateLocation(id: string, name: string): Promise<void> {
-        const { error } = await supabase.from('locations').update({ name }).eq('id', id);
+    async updateLocation(id: string, values: { name: string; organization_id?: string }): Promise<void> {
+        const patch: { name: string; organization_id?: string } = { name: values.name };
+        if (values.organization_id) patch.organization_id = values.organization_id; // Superadmin only (RLS)
+        const { error } = await supabase.from('locations').update(patch).eq('id', id);
         if (error) throw error;
     },
 

--- a/src/features/admin/components/LocationForm.tsx
+++ b/src/features/admin/components/LocationForm.tsx
@@ -27,8 +27,9 @@ export function LocationForm({ location, onClose }: { location?: LocationEditTar
     const [isBusy, setIsBusy] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
-    // Only Superadmins editing across orgs need a selector, and only on create.
-    const showOrgSelect = !isEdit && isSuperAdmin && (adminData?.length ?? 0) > 1;
+    // Superadmins can pick the organization — both when creating and when moving
+    // an existing location to another org.
+    const showOrgSelect = isSuperAdmin && (adminData?.length ?? 0) > 1;
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -40,7 +41,10 @@ export function LocationForm({ location, onClose }: { location?: LocationEditTar
         setError(null);
         try {
             if (isEdit && location) {
-                await updateLocation(location.id, trimmedName);
+                await updateLocation(location.id, {
+                    name: trimmedName,
+                    ...(isSuperAdmin ? { organization_id: organizationId } : {}),
+                });
             } else {
                 await createLocation({ organization_id: organizationId, name: trimmedName });
             }


### PR DESCRIPTION
A Superadmin couldn't change a location's organization in the UI: the org selector in LocationForm was create-only (`!isEdit`) and `updateLocation` only patched the name.

- Show the organization selector on **edit** too (Superadmin, >1 org).
- `updateLocation(id, { name, organization_id? })` now passes `organization_id` (Superadmin only).
- No DB change — RLS already permits it via the *Superadmin full access to locations* policy.

typecheck/lint/test/build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)