### PR TITLE
fix(locations): guard org-move + keep current location visible when archived

### DIFF
--- a/src/app/layout/HomePage.tsx
+++ b/src/app/layout/HomePage.tsx
@@ -22,8 +22,9 @@ export function HomePage() {
   if (!user) return null;
 
   // Archived locations stay available for history-name resolution (Overview) but
-  // must not appear as places you can pick or clock in at.
-  const activeLocations = locations.filter((l) => !l.archived_at);
+  // must not appear as places you can pick or clock in at — except the one you're
+  // currently clocked into, so you never lose sight of where you are.
+  const activeLocations = locations.filter((l) => !l.archived_at || l.id === activeShift?.location_id);
 
   return (
     <>

--- a/src/features/admin/adminService.tsx
+++ b/src/features/admin/adminService.tsx
@@ -70,6 +70,17 @@ export const adminService = {
         return z.array(RoleSchema).parse(data ?? []);
     },
 
+    /** True if anyone is currently clocked in at this location (open shift). */
+    async hasActiveShiftsAtLocation(locationId: string): Promise<boolean> {
+        const { count, error } = await supabase
+            .from('shifts')
+            .select('id', { count: 'exact', head: true })
+            .eq('location_id', locationId)
+            .is('ended_at', null);
+        if (error) throw error;
+        return (count ?? 0) > 0;
+    },
+
     async getAllActiveShifts(organizationId: string, isSuperAdmin: boolean): Promise<Shift[]> {
         let query = supabase
             .from('shifts')

--- a/src/features/admin/components/LocationForm.tsx
+++ b/src/features/admin/components/LocationForm.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Modal } from './Modal';
 import { Field, TextInput, SelectInput, FormError, FormActions } from './FormControls';
 import { useAdminContext } from '../AdminContext';
+import { adminService } from '../adminService';
 import { useAuthContext } from '@/features/auth/AuthContext';
 
 export interface LocationEditTarget {
@@ -41,6 +42,15 @@ export function LocationForm({ location, onClose }: { location?: LocationEditTar
         setError(null);
         try {
             if (isEdit && location) {
+                // Moving a location to another org while someone is clocked in
+                // there leaves their shift stranded in the old org (shows up as
+                // "Unknown Location"). Block it until the shift is ended.
+                const orgChanged = isSuperAdmin && organizationId !== location.organization_id;
+                if (orgChanged && (await adminService.hasActiveShiftsAtLocation(location.id))) {
+                    setError('Someone is currently clocked in here. End their active shift before moving this location to another organization.');
+                    setIsBusy(false);
+                    return;
+                }
                 await updateLocation(location.id, {
                     name: trimmedName,
                     ...(isSuperAdmin ? { organization_id: organizationId } : {}),

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -43,7 +43,9 @@ export function Dashboard({ onLocationSelect }: DashboardProps) {
   const currentRoute = useLocation();
 
   const filteredLocations = locations.filter(loc =>
-    !loc.archived_at && loc.name.toLowerCase().includes(searchQuery.toLowerCase())
+    // hide archived, but keep the one you're currently clocked into
+    (!loc.archived_at || loc.id === selectedLocationId) &&
+    loc.name.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
   return (

--- a/src/features/shifts/components/ActiveShift.tsx
+++ b/src/features/shifts/components/ActiveShift.tsx
@@ -64,6 +64,8 @@ export function ActiveShift() {
                     <LiveClockIcon className="h-4 w-4" isActive={true} />
                     Active Shift: {startTime}
                 </div>
+                {/* Make it obvious WHERE you're clocked in (esp. on phone). */}
+                <p className="mt-2 text-body-strong text-gray-900 dark:text-white text-center">{locationName}</p>
                 {previousLocation && (
                     <div className="mt-2 flex items-center gap-1 text-micro text-gray-500">
                         <span>Moved from {previousLocation.name}</span>


### PR DESCRIPTION
Follow-ups to the location move/archive features.

**Moving a location with people on it** — moving a location to another org leaves existing shifts behind in the *old* org (the shift keeps its organization_id while the location leaves), so the worker sees 'Unknown Location' and history names stop resolving. Now blocked when there's an **active** shift there, with a clear message (end the shift first). Finished/historical shifts don't block the move (hours are preserved; only the location name may not resolve cross-org).

**Lost sight of your location when it's archived** — archiving filtered the location out everywhere, including for the person currently clocked into it. Now the location you're **currently on** stays visible on Home + the Dashboard sidebar even if archived, and the **mobile** Active Shift banner shows the location name (previously only the start time).

typecheck/lint/test/build ✓. No DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)