### PR TITLE
feat(profile): name-change requests + weekly username limit

### DIFF
--- a/src/features/admin/AdminContext.tsx
+++ b/src/features/admin/AdminContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useCallback, type ReactNode } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { adminService, type EmployeeUpdate, type EmployeeInvite } from './adminService';
 import { useAuthContext } from '@/features/auth/AuthContext';
-import type { Organization, Role } from '@/shared/types';
+import type { Organization, Role, NameChangeRequest } from '@/shared/types';
 
 /**
  * --- ADMIN CONTEXT ---
@@ -36,12 +36,17 @@ interface AdminContextType {
     inviteEmployee: (payload: EmployeeInvite) => Promise<void>;
     updateEmployee: (id: string, values: EmployeeUpdate) => Promise<void>;
     deleteEmployee: (id: string) => Promise<void>;
+
+    // Name change requests
+    nameRequests: NameChangeRequest[];
+    reviewNameRequest: (id: string, approve: boolean, note?: string | null) => Promise<void>;
 }
 
 const AdminContext = createContext<AdminContextType | undefined>(undefined);
 
 const TREE_KEY = ['admin', 'tree'] as const;
 const ROLES_KEY = ['admin', 'roles'] as const;
+const REQUESTS_KEY = ['admin', 'name-requests'] as const;
 
 export function AdminProvider({ children }: { children: ReactNode }) {
     const { user } = useAuthContext();
@@ -59,6 +64,14 @@ export function AdminProvider({ children }: { children: ReactNode }) {
         queryFn: () => adminService.getRoles(),
         enabled: !!user,
         staleTime: 5 * 60 * 1000, // roles rarely change
+    });
+
+    // Only admins (rank >= 30) can see/review name-change requests.
+    const canReview = (user?.role.rank ?? 0) >= 30;
+    const requestsQuery = useQuery({
+        queryKey: [...REQUESTS_KEY, user?.id],
+        queryFn: () => adminService.getNameChangeRequests(),
+        enabled: !!user && canReview,
     });
 
     const invalidateTree = useCallback(
@@ -136,6 +149,19 @@ export function AdminProvider({ children }: { children: ReactNode }) {
         [user?.id, run],
     );
 
+    // Name change requests ------------------------------------------
+    const reviewNameRequest = useCallback(
+        async (id: string, approve: boolean, note?: string | null) => {
+            await adminService.reviewNameChange(id, approve, note);
+            // Approval renames a member, so refresh both the requests and the tree.
+            await Promise.all([
+                queryClient.invalidateQueries({ queryKey: REQUESTS_KEY }),
+                invalidateTree(),
+            ]);
+        },
+        [queryClient, invalidateTree],
+    );
+
     const value: AdminContextType = {
         adminData: treeQuery.data ?? null,
         roles: rolesQuery.data ?? [],
@@ -158,6 +184,8 @@ export function AdminProvider({ children }: { children: ReactNode }) {
         inviteEmployee,
         updateEmployee,
         deleteEmployee,
+        nameRequests: requestsQuery.data ?? [],
+        reviewNameRequest,
     };
 
     return <AdminContext.Provider value={value}>{children}</AdminContext.Provider>;

--- a/src/features/admin/AdminPage.tsx
+++ b/src/features/admin/AdminPage.tsx
@@ -7,12 +7,14 @@ import {
     PlusIcon,
     PaperPlaneTiltIcon,
     MagnifyingGlassIcon,
+    UserCircleGearIcon,
 } from '@phosphor-icons/react';
 import type { Organization, Profile } from '@/shared/types';
 
 import { useAuthContext } from '@/features/auth/AuthContext';
 import { AdminProvider, useAdminContext } from './AdminContext';
 import { canManageEmployees, canManageLocations } from './permissions';
+import { NameChangeRequestsList } from './components/NameChangeRequestsList';
 import { ConfirmDialog } from './components/Modal';
 import { OrganizationForm } from './components/OrganizationForm';
 import { LocationForm, type LocationEditTarget } from './components/LocationForm';
@@ -23,7 +25,7 @@ import { OrganizationsList } from './components/OrganizationsList';
 import { LocationsList, type LocationRow } from './components/LocationsList';
 import { EmployeesList, type EmployeeRow } from './components/EmployeesList';
 
-type TabType = 'employees' | 'locations' | 'organizations';
+type TabType = 'employees' | 'locations' | 'organizations' | 'requests';
 
 type ModalState =
     | { kind: 'org-form'; org?: Organization }
@@ -37,6 +39,7 @@ const ADD_LABEL: Record<TabType, string> = {
     organizations: 'Add Organization',
     locations: 'Add Location',
     employees: 'Invite Employee',
+    requests: '',
 };
 
 /**
@@ -61,8 +64,14 @@ function AdminPanel() {
         deleteOrganization,
         deleteLocation,
         deleteEmployee,
+        nameRequests,
+        reviewNameRequest,
     } = useAdminContext();
     const { user } = useAuthContext();
+
+    // Admin (rank >= 30) capability — also gates the name-change requests tab.
+    const canManageEmp = user ? canManageEmployees(user) : false;
+    const canManageLoc = user ? canManageLocations(user) : false;
 
     const [activeTab, setActiveTab] = useState<TabType>('employees');
     const [searchQuery, setSearchQuery] = useState('');
@@ -71,12 +80,16 @@ function AdminPanel() {
     const tabs = [
         { id: 'employees', label: 'Employees', icon: UsersIcon },
         { id: 'locations', label: 'Locations', icon: MapPinIcon },
+        ...(canManageEmp ? [{ id: 'requests', label: 'Requests', icon: UserCircleGearIcon }] : []),
         ...(isSuperAdmin ? [{ id: 'organizations', label: 'Organizations', icon: BuildingsIcon }] : []),
     ] as const;
 
-    // Guard against showing the Organizations tab to a non-Superadmin (e.g. if
-    // their role changes mid-session) without a setState-in-effect round trip.
-    const safeTab: TabType = activeTab === 'organizations' && !isSuperAdmin ? 'employees' : activeTab;
+    // Guard against showing a tab the user may not access (e.g. if their role
+    // changes mid-session) without a setState-in-effect round trip.
+    const safeTab: TabType =
+        (activeTab === 'organizations' && !isSuperAdmin) || (activeTab === 'requests' && !canManageEmp)
+            ? 'employees'
+            : activeTab;
 
     // --- Derived, flattened + searched collections ---
     const query = searchQuery.trim().toLowerCase();
@@ -134,10 +147,14 @@ function AdminPanel() {
     const empCount = adminData?.reduce((n, o) => n + o.profiles.length, 0) ?? 0;
 
     // Capability flags drive what the current user can do (mirrors RLS).
-    const canManageEmp = user ? canManageEmployees(user) : false;
-    const canManageLoc = user ? canManageLocations(user) : false;
     const canAdd =
-        safeTab === 'employees' ? canManageEmp : safeTab === 'locations' ? canManageLoc : isSuperAdmin;
+        safeTab === 'employees'
+            ? canManageEmp
+            : safeTab === 'locations'
+              ? canManageLoc
+              : safeTab === 'organizations'
+                ? isSuperAdmin
+                : false; // 'requests' has no "add" action
 
     return (
         <div className="space-y-6 px-1 max-w-7xl mx-auto w-full">
@@ -205,6 +222,11 @@ function AdminPanel() {
                                 )}
                                 <tab.icon weight={isActive ? 'fill' : 'bold'} className="w-5 h-5 sm:w-4 sm:h-4 relative z-10" />
                                 <span className="relative z-10 hidden sm:block">{tab.label}</span>
+                                {tab.id === 'requests' && nameRequests.length > 0 && (
+                                    <span className="relative z-10 ml-0.5 min-w-4 h-4 px-1 rounded-full bg-emerald-500 text-white text-[10px] font-bold flex items-center justify-center">
+                                        {nameRequests.length}
+                                    </span>
+                                )}
                             </button>
                         );
                     })}
@@ -272,6 +294,13 @@ function AdminPanel() {
                                             label: `${emp.first_name ?? ''} ${emp.last_name ?? ''}`.trim() || emp.username,
                                         })
                                     }
+                                />
+                            )}
+                            {safeTab === 'requests' && (
+                                <NameChangeRequestsList
+                                    items={nameRequests}
+                                    isLoading={isLoading}
+                                    onReview={reviewNameRequest}
                                 />
                             )}
                         </motion.div>

--- a/src/features/admin/adminService.tsx
+++ b/src/features/admin/adminService.tsx
@@ -3,9 +3,11 @@ import {
     type Shift,
     type Organization,
     type Role,
+    type NameChangeRequest,
     OrganizationSchema,
     ShiftSchema,
     RoleSchema,
+    NameChangeRequestSchema,
     type User,
 } from '@shared/types';
 import { z } from 'zod';
@@ -165,6 +167,37 @@ export const adminService = {
             body: { user_id: id },
         });
         if (error) throw await toFunctionError(error);
+    },
+
+    // ----------------------------------------------------------------
+    // NAME CHANGE REQUESTS
+    // ----------------------------------------------------------------
+
+    /**
+     * Pending name-change requests visible to the caller (RLS scopes them to the
+     * admin's organization; Superadmin sees all). Includes the requester profile.
+     */
+    async getNameChangeRequests(): Promise<NameChangeRequest[]> {
+        const { data, error } = await supabase
+            .from('name_change_requests')
+            .select(
+                'id, user_id, organization_id, current_first_name, current_last_name, requested_first_name, requested_last_name, note, review_note, status, reviewed_at, created_at, requester:profiles!name_change_requests_user_id_fkey(username, email, first_name, last_name)',
+            )
+            .eq('status', 'pending')
+            .order('created_at', { ascending: true });
+
+        if (error) throw error;
+        return z.array(NameChangeRequestSchema).parse(data ?? []);
+    },
+
+    /** Approve or reject a request (SECURITY DEFINER RPC enforces authorization). */
+    async reviewNameChange(id: string, approve: boolean, note?: string | null): Promise<void> {
+        const { error } = await supabase.rpc('review_name_change_request', {
+            p_id: id,
+            p_approve: approve,
+            p_review_note: note ?? null,
+        });
+        if (error) throw new Error(error.message);
     },
 
     /**

--- a/src/features/admin/components/NameChangeRequestsList.tsx
+++ b/src/features/admin/components/NameChangeRequestsList.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import {
+    CheckIcon,
+    XIcon,
+    UserIcon,
+    ArrowRightIcon,
+} from '@phosphor-icons/react';
+import type { NameChangeRequest } from '@shared/types';
+import { LoadingState, EmptyState } from './AdminStateViews';
+
+/**
+ * Pending name-change requests for the admin to approve or reject. Approving
+ * applies the requested name to the member's profile (server-side, atomically).
+ */
+export function NameChangeRequestsList({
+    items,
+    isLoading,
+    onReview,
+}: {
+    items: NameChangeRequest[];
+    isLoading: boolean;
+    onReview: (id: string, approve: boolean, note?: string | null) => Promise<void>;
+}) {
+    if (isLoading) return <LoadingState label="requests" />;
+    if (items.length === 0) return <EmptyState label="pending requests" />;
+
+    return (
+        <div className="space-y-2">
+            {items.map((req) => (
+                <RequestRow key={req.id} req={req} onReview={onReview} />
+            ))}
+        </div>
+    );
+}
+
+function fullName(first?: string | null, last?: string | null): string {
+    return `${first ?? ''} ${last ?? ''}`.trim() || '—';
+}
+
+function RequestRow({
+    req,
+    onReview,
+}: {
+    req: NameChangeRequest;
+    onReview: (id: string, approve: boolean, note?: string | null) => Promise<void>;
+}) {
+    const [busy, setBusy] = useState<null | 'approve' | 'reject'>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const act = async (approve: boolean) => {
+        setError(null);
+        setBusy(approve ? 'approve' : 'reject');
+        try {
+            await onReview(req.id, approve);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Action failed.');
+            setBusy(null);
+        }
+    };
+
+    return (
+        <div className="bg-white dark:bg-gray-800/40 border border-gray-100 dark:border-gray-800 rounded-2xl shadow-sm p-4">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+                {/* who */}
+                <div className="flex items-center gap-3 min-w-0 flex-1">
+                    <div className="w-9 h-9 rounded-xl bg-gray-100 dark:bg-gray-900/50 flex items-center justify-center text-gray-500 dark:text-gray-400 shrink-0">
+                        <UserIcon weight="bold" className="w-4 h-4" />
+                    </div>
+                    <div className="min-w-0">
+                        <p className="text-body-strong text-gray-900 dark:text-white truncate">
+                            @{req.requester?.username ?? '—'}
+                        </p>
+                        <p className="text-caption text-gray-400 truncate">{req.requester?.email ?? ''}</p>
+                    </div>
+                </div>
+
+                {/* current -> requested */}
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                    <span className="text-small text-gray-500 dark:text-gray-400 truncate">
+                        {fullName(req.current_first_name, req.current_last_name)}
+                    </span>
+                    <ArrowRightIcon weight="bold" className="w-4 h-4 text-emerald-500 shrink-0" />
+                    <span className="text-small-strong text-gray-900 dark:text-white truncate">
+                        {fullName(req.requested_first_name, req.requested_last_name)}
+                    </span>
+                </div>
+
+                {/* actions */}
+                <div className="flex items-center gap-2 shrink-0">
+                    <button
+                        onClick={() => act(true)}
+                        disabled={busy !== null}
+                        className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-small-strong text-white bg-emerald-500 hover:bg-emerald-600 transition-colors disabled:opacity-50"
+                    >
+                        <CheckIcon weight="bold" className="w-4 h-4" />
+                        {busy === 'approve' ? '…' : 'Approve'}
+                    </button>
+                    <button
+                        onClick={() => act(false)}
+                        disabled={busy !== null}
+                        className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-small-strong text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/15 hover:bg-red-100 dark:hover:bg-red-900/25 transition-colors disabled:opacity-50"
+                    >
+                        <XIcon weight="bold" className="w-4 h-4" />
+                        {busy === 'reject' ? '…' : 'Reject'}
+                    </button>
+                </div>
+            </div>
+
+            {req.note && (
+                <p className="text-caption text-gray-500 dark:text-gray-400 mt-3 pl-12">“{req.note}”</p>
+            )}
+            {error && <p className="text-caption text-red-500 mt-2 pl-12">{error}</p>}
+        </div>
+    );
+}

--- a/src/features/auth/authService.ts
+++ b/src/features/auth/authService.ts
@@ -1,6 +1,6 @@
 import { supabase } from '@shared/api/supabaseClient';
-import { type User } from '@shared/types';
-import { ProfileSchema } from '@shared/types';
+import { type User, type NameChangeRequest } from '@shared/types';
+import { ProfileSchema, NameChangeRequestSchema } from '@shared/types';
 
 /**
  * --- AUTH SERVICE ---
@@ -24,7 +24,7 @@ export const authService = {
   async getUserProfile(userId: string): Promise<User | null> {
     const { data, error } = await supabase
       .from('profiles')
-      .select('id, username, first_name, last_name, role(name, is_admin, rank), email, organization_id')
+      .select('id, username, first_name, last_name, role(name, is_admin, rank), email, organization_id, username_changed_at')
       .eq('id', userId)
       .single();
 
@@ -44,7 +44,8 @@ export const authService = {
       },
       email: validated.email,
       last_name: validated.last_name ?? null,
-      organization_id: validated.organization_id
+      organization_id: validated.organization_id,
+      username_changed_at: validated.username_changed_at ?? null
     };
   },
 
@@ -96,5 +97,40 @@ export const authService = {
     fields: { username?: string; first_name?: string | null; last_name?: string | null }
   ) {
     return await supabase.from('profiles').update(fields).eq('id', userId);
-  }
+  },
+
+  /**
+   * The caller's most recent name-change request (any status), or null.
+   * Staff use this to see whether they already have one pending.
+   */
+  async getMyLatestNameRequest(userId: string): Promise<NameChangeRequest | null> {
+    const { data, error } = await supabase
+      .from('name_change_requests')
+      .select(
+        'id, user_id, organization_id, current_first_name, current_last_name, requested_first_name, requested_last_name, note, review_note, status, reviewed_at, created_at',
+      )
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) throw error;
+    return data ? NameChangeRequestSchema.parse(data) : null;
+  },
+
+  /** Submit a request to change your first/last name (SECURITY DEFINER RPC). */
+  async requestNameChange(firstName: string, lastName: string, note?: string | null) {
+    const { error } = await supabase.rpc('request_name_change', {
+      p_first_name: firstName,
+      p_last_name: lastName,
+      p_note: note ?? null,
+    });
+    if (error) throw new Error(error.message);
+  },
+
+  /** Cancel your own pending name-change request. */
+  async cancelNameChange(requestId: string) {
+    const { error } = await supabase.rpc('cancel_name_change_request', { p_id: requestId });
+    if (error) throw new Error(error.message);
+  },
 };

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, type SyntheticEvent } from 'react';
+import { useState, useEffect, useCallback, type SyntheticEvent } from 'react';
 import {
   AtIcon,
   PaletteIcon,
@@ -6,76 +6,176 @@ import {
   IdentificationBadgeIcon,
   CheckCircleIcon,
   SignOutIcon,
+  LockIcon,
+  ClockIcon,
+  PaperPlaneTiltIcon,
+  HourglassMediumIcon,
+  XCircleIcon,
 } from '@phosphor-icons/react';
 import { useAuthContext } from '@features/auth/AuthContext';
 import { authService } from '@features/auth/authService';
 import { useTheme } from '@app/providers/ThemeContext';
 import { getRoleBadgeColor } from '@shared/utils/roleColors';
+import type { NameChangeRequest } from '@shared/types';
 
 /**
  * --- SETTINGS PAGE ---
- * Lets the signed-in user edit their own profile. The username is the login
- * identifier (you can sign in with it instead of your email), so it must stay
- * unique — the DB unique_username constraint is the source of truth.
+ * The signed-in user manages their own profile here.
+ *
+ * Rules (enforced in the DB, mirrored in this UI):
+ *  - Username is self-service but can only change once every 7 days.
+ *  - Staff (rank < 30) cannot edit their own first/last name — they file a
+ *    request that an admin approves. Admins (rank >= 30) edit names directly.
  */
 
 const USERNAME_RE = /^[a-z0-9._-]{3,30}$/;
+const ADMIN_RANK = 30;
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+const fieldClass =
+  'w-full bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 focus:border-emerald-500 rounded-xl px-3 py-2.5 text-body outline-none text-gray-900 dark:text-white transition-colors disabled:opacity-60 disabled:cursor-not-allowed';
+const cardClass =
+  'bg-white dark:bg-gray-800/40 border border-gray-100 dark:border-gray-800 rounded-3xl shadow-sm';
 
 export default function SettingsPage() {
   const { user, refreshUser, logout } = useAuthContext();
   const { resolvedTheme, setTheme } = useTheme();
   const isDark = resolvedTheme === 'dark';
 
+  const isStaff = (user?.role.rank ?? 0) < ADMIN_RANK;
+
+  // username (self-service, weekly limited)
   const [username, setUsername] = useState(user?.username ?? '');
+  const [busyUser, setBusyUser] = useState(false);
+  const [userErr, setUserErr] = useState<string | null>(null);
+  const [userSaved, setUserSaved] = useState(false);
+
+  // name (admins edit directly)
   const [firstName, setFirstName] = useState(user?.first_name ?? '');
   const [lastName, setLastName] = useState(user?.last_name ?? '');
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [saved, setSaved] = useState(false);
+  const [busyName, setBusyName] = useState(false);
+  const [nameErr, setNameErr] = useState<string | null>(null);
+  const [nameSaved, setNameSaved] = useState(false);
+
+  // name change request (staff)
+  const [latestRequest, setLatestRequest] = useState<NameChangeRequest | null>(null);
+  const [showRequest, setShowRequest] = useState(false);
+  const [reqFirst, setReqFirst] = useState(user?.first_name ?? '');
+  const [reqLast, setReqLast] = useState(user?.last_name ?? '');
+  const [reqNote, setReqNote] = useState('');
+  const [busyReq, setBusyReq] = useState(false);
+  const [reqErr, setReqErr] = useState<string | null>(null);
+
+  const loadRequest = useCallback(async () => {
+    if (!user || !isStaff) return;
+    try {
+      setLatestRequest(await authService.getMyLatestNameRequest(user.id));
+    } catch (err) {
+      console.error('Failed to load name request:', err);
+    }
+  }, [user, isStaff]);
+
+  useEffect(() => {
+    loadRequest();
+  }, [loadRequest]);
 
   if (!user) return null;
 
+  // --- username weekly limit ---
+  const lastChanged = user.username_changed_at ? new Date(user.username_changed_at).getTime() : null;
+  const nextAllowedAt = lastChanged ? lastChanged + WEEK_MS : null;
+  const usernameLocked = nextAllowedAt ? Date.now() < nextAllowedAt : false;
+  const nextAllowedStr = nextAllowedAt
+    ? new Date(nextAllowedAt).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+    : '';
+
   const normalizedUsername = username.trim().toLowerCase();
-  const dirty =
-    normalizedUsername !== (user.username ?? '') ||
-    firstName.trim() !== (user.first_name ?? '') ||
-    lastName.trim() !== (user.last_name ?? '');
+  const usernameDirty = normalizedUsername !== (user.username ?? '');
 
-  const handleSubmit = async (e: SyntheticEvent) => {
+  const saveUsername = async (e: SyntheticEvent) => {
     e.preventDefault();
-    setError(null);
-    setSaved(false);
-
+    setUserErr(null);
+    setUserSaved(false);
     if (!USERNAME_RE.test(normalizedUsername)) {
-      setError('Username must be 3–30 characters: lowercase letters, numbers, dot, underscore or hyphen.');
+      setUserErr('Username must be 3–30 characters: lowercase letters, numbers, dot, underscore or hyphen.');
       return;
     }
+    setBusyUser(true);
+    const { error } = await authService.updateProfile(user.id, { username: normalizedUsername });
+    if (error) {
+      setUserErr(
+        error.code === '23505'
+          ? 'That username is already taken. Please choose another.'
+          : error.message || 'Could not update your username.',
+      );
+      setBusyUser(false);
+      return;
+    }
+    await refreshUser();
+    setUsername(normalizedUsername);
+    setBusyUser(false);
+    setUserSaved(true);
+  };
 
-    setBusy(true);
-    const { error: updateError } = await authService.updateProfile(user.id, {
-      username: normalizedUsername,
+  // --- name (admins) ---
+  const nameDirty = firstName.trim() !== (user.first_name ?? '') || lastName.trim() !== (user.last_name ?? '');
+
+  const saveName = async (e: SyntheticEvent) => {
+    e.preventDefault();
+    setNameErr(null);
+    setNameSaved(false);
+    setBusyName(true);
+    const { error } = await authService.updateProfile(user.id, {
       first_name: firstName.trim() || null,
       last_name: lastName.trim() || null,
     });
-
-    if (updateError) {
-      setError(
-        updateError.code === '23505'
-          ? 'That username is already taken. Please choose another.'
-          : updateError.message || 'Could not save your changes.',
-      );
-      setBusy(false);
+    if (error) {
+      setNameErr(error.message || 'Could not update your name.');
+      setBusyName(false);
       return;
     }
-
     await refreshUser();
-    setUsername(normalizedUsername);
-    setBusy(false);
-    setSaved(true);
+    setBusyName(false);
+    setNameSaved(true);
   };
 
-  const fieldClass =
-    'w-full bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 focus:border-emerald-500 rounded-xl px-3 py-2.5 text-body outline-none text-gray-900 dark:text-white transition-colors';
+  // --- name change request (staff) ---
+  const submitRequest = async (e: SyntheticEvent) => {
+    e.preventDefault();
+    setReqErr(null);
+    if (!reqFirst.trim() && !reqLast.trim()) {
+      setReqErr('Enter the first and/or last name you would like.');
+      return;
+    }
+    setBusyReq(true);
+    try {
+      await authService.requestNameChange(reqFirst.trim(), reqLast.trim(), reqNote.trim() || null);
+      setShowRequest(false);
+      setReqNote('');
+      await loadRequest();
+    } catch (err) {
+      setReqErr(err instanceof Error ? err.message : 'Could not submit your request.');
+    } finally {
+      setBusyReq(false);
+    }
+  };
+
+  const cancelRequest = async () => {
+    if (!latestRequest) return;
+    setBusyReq(true);
+    try {
+      await authService.cancelNameChange(latestRequest.id);
+      await loadRequest();
+    } catch (err) {
+      setReqErr(err instanceof Error ? err.message : 'Could not cancel your request.');
+    } finally {
+      setBusyReq(false);
+    }
+  };
+
+  const fullName =
+    user.first_name || user.last_name ? `${user.first_name ?? ''} ${user.last_name ?? ''}`.trim() : '—';
+  const pending = latestRequest?.status === 'pending' ? latestRequest : null;
 
   return (
     <div className="space-y-6 px-1 max-w-2xl">
@@ -85,20 +185,14 @@ export default function SettingsPage() {
       </header>
 
       {/* USER PREVIEW */}
-      <div className="p-4 bg-white dark:bg-gray-800/40 border border-gray-100 dark:border-gray-800 rounded-3xl shadow-sm flex items-center gap-4">
+      <div className={`${cardClass} p-4 flex items-center gap-4`}>
         <div className="w-14 h-14 rounded-full bg-emerald-100 dark:bg-emerald-900/40 border-2 border-white dark:border-white/10 flex items-center justify-center text-emerald-700 dark:text-emerald-400 text-lg font-black shrink-0">
           {(user.first_name?.[0] || user.username?.[0] || '?').toUpperCase()}
         </div>
         <div className="min-w-0">
-          <h2 className="text-title text-gray-900 dark:text-white truncate">
-            {user.first_name || user.last_name ? `${user.first_name ?? ''} ${user.last_name ?? ''}`.trim() : user.username}
-          </h2>
+          <h2 className="text-title text-gray-900 dark:text-white truncate">{fullName === '—' ? user.username : fullName}</h2>
           <div className="flex items-center gap-2 mt-1">
-            <span
-              className={`inline-block px-2 py-0.5 text-micro rounded-md ${getRoleBadgeColor(
-                user.role.name,
-              )}`}
-            >
+            <span className={`inline-block px-2 py-0.5 text-micro rounded-md ${getRoleBadgeColor(user.role.name)}`}>
               {user.role.name}
             </span>
             <span className="text-caption text-gray-400">@{user.username}</span>
@@ -106,10 +200,10 @@ export default function SettingsPage() {
         </div>
       </div>
 
-      {/* PROFILE FORM */}
-      <form onSubmit={handleSubmit} className="space-y-2">
-        <h3 className="px-1 text-label text-gray-400">Profile</h3>
-        <div className="bg-white dark:bg-gray-800/40 border border-gray-100 dark:border-gray-800 rounded-3xl shadow-sm p-5 space-y-4">
+      {/* USERNAME */}
+      <form onSubmit={saveUsername} className="space-y-2">
+        <h3 className="px-1 text-label text-gray-400">Username</h3>
+        <div className={`${cardClass} p-5 space-y-4`}>
           <div>
             <label className="flex items-center gap-1.5 text-small-strong text-gray-600 dark:text-gray-300 mb-1.5">
               <AtIcon weight="bold" className="w-3.5 h-3.5 text-emerald-500" />
@@ -122,45 +216,196 @@ export default function SettingsPage() {
               autoCapitalize="none"
               autoCorrect="off"
               spellCheck={false}
+              disabled={usernameLocked}
               className={fieldClass}
             />
-            <p className="text-caption text-gray-400 mt-1.5">Used to sign in instead of your email. Must be unique.</p>
+            {usernameLocked ? (
+              <p className="flex items-center gap-1.5 text-caption text-amber-600 dark:text-amber-400 mt-1.5">
+                <ClockIcon weight="bold" className="w-3.5 h-3.5" />
+                You can change your username again on {nextAllowedStr}.
+              </p>
+            ) : (
+              <p className="text-caption text-gray-400 mt-1.5">
+                Used to sign in instead of your email. Must be unique. Can be changed once every 7 days.
+              </p>
+            )}
           </div>
 
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="text-small-strong text-gray-600 dark:text-gray-300 mb-1.5 block">First name</label>
-              <input value={firstName} onChange={(e) => setFirstName(e.target.value)} placeholder="First name" className={fieldClass} />
-            </div>
-            <div>
-              <label className="text-small-strong text-gray-600 dark:text-gray-300 mb-1.5 block">Last name</label>
-              <input value={lastName} onChange={(e) => setLastName(e.target.value)} placeholder="Last name" className={fieldClass} />
-            </div>
-          </div>
-
-          {error && (
-            <p className="text-small-strong text-red-500 bg-red-50 dark:bg-red-900/20 rounded-xl px-3 py-2">{error}</p>
+          {userErr && (
+            <p className="text-small-strong text-red-500 bg-red-50 dark:bg-red-900/20 rounded-xl px-3 py-2">{userErr}</p>
           )}
-          {saved && !error && (
+          {userSaved && !userErr && (
             <p className="flex items-center gap-1.5 text-small-strong text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 rounded-xl px-3 py-2">
-              <CheckCircleIcon weight="fill" className="w-4 h-4" /> Changes saved.
+              <CheckCircleIcon weight="fill" className="w-4 h-4" /> Username updated.
             </p>
           )}
 
           <button
             type="submit"
-            disabled={busy || !dirty}
+            disabled={busyUser || usernameLocked || !usernameDirty}
             className="w-full px-4 py-3 rounded-xl text-body-strong text-white bg-emerald-500 hover:bg-emerald-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-emerald-500/25"
           >
-            {busy ? 'Saving…' : 'Save changes'}
+            {busyUser ? 'Saving…' : 'Save username'}
           </button>
         </div>
       </form>
 
+      {/* NAME — admins edit directly; staff request a change */}
+      <div className="space-y-2">
+        <h3 className="px-1 text-label text-gray-400">Name</h3>
+
+        {!isStaff ? (
+          <form onSubmit={saveName} className={`${cardClass} p-5 space-y-4`}>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-small-strong text-gray-600 dark:text-gray-300 mb-1.5 block">First name</label>
+                <input value={firstName} onChange={(e) => setFirstName(e.target.value)} placeholder="First name" className={fieldClass} />
+              </div>
+              <div>
+                <label className="text-small-strong text-gray-600 dark:text-gray-300 mb-1.5 block">Last name</label>
+                <input value={lastName} onChange={(e) => setLastName(e.target.value)} placeholder="Last name" className={fieldClass} />
+              </div>
+            </div>
+            {nameErr && (
+              <p className="text-small-strong text-red-500 bg-red-50 dark:bg-red-900/20 rounded-xl px-3 py-2">{nameErr}</p>
+            )}
+            {nameSaved && !nameErr && (
+              <p className="flex items-center gap-1.5 text-small-strong text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 rounded-xl px-3 py-2">
+                <CheckCircleIcon weight="fill" className="w-4 h-4" /> Name updated.
+              </p>
+            )}
+            <button
+              type="submit"
+              disabled={busyName || !nameDirty}
+              className="w-full px-4 py-3 rounded-xl text-body-strong text-white bg-emerald-500 hover:bg-emerald-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-emerald-500/25"
+            >
+              {busyName ? 'Saving…' : 'Save name'}
+            </button>
+          </form>
+        ) : (
+          <div className={`${cardClass} p-5 space-y-4`}>
+            {/* read-only current name */}
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-small-strong text-gray-600 dark:text-gray-300 mb-1.5 block">First name</label>
+                <div className="flex items-center gap-2 rounded-xl bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 px-3 py-2.5 text-body text-gray-700 dark:text-gray-200">
+                  <LockIcon weight="bold" className="w-3.5 h-3.5 text-gray-400 shrink-0" />
+                  <span className="truncate">{user.first_name || '—'}</span>
+                </div>
+              </div>
+              <div>
+                <label className="text-small-strong text-gray-600 dark:text-gray-300 mb-1.5 block">Last name</label>
+                <div className="flex items-center gap-2 rounded-xl bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 px-3 py-2.5 text-body text-gray-700 dark:text-gray-200">
+                  <LockIcon weight="bold" className="w-3.5 h-3.5 text-gray-400 shrink-0" />
+                  <span className="truncate">{user.last_name || '—'}</span>
+                </div>
+              </div>
+            </div>
+
+            <p className="text-caption text-gray-400">
+              Your name can only be changed by an administrator. Send a request below and an admin will review it.
+            </p>
+
+            {/* pending request banner */}
+            {pending && (
+              <div className="rounded-xl bg-amber-50 dark:bg-amber-900/15 border border-amber-200/70 dark:border-amber-900/30 px-3 py-3 space-y-2">
+                <div className="flex items-center gap-2 text-amber-700 dark:text-amber-400">
+                  <HourglassMediumIcon weight="fill" className="w-4 h-4" />
+                  <p className="text-small-strong">Request pending review</p>
+                </div>
+                <p className="text-caption text-amber-700/90 dark:text-amber-300/80">
+                  Requested: <span className="font-semibold">{`${pending.requested_first_name ?? ''} ${pending.requested_last_name ?? ''}`.trim() || '—'}</span>
+                </p>
+                <button
+                  onClick={cancelRequest}
+                  disabled={busyReq}
+                  className="text-caption font-semibold text-amber-700 dark:text-amber-300 underline underline-offset-2 disabled:opacity-50"
+                >
+                  Cancel request
+                </button>
+              </div>
+            )}
+
+            {/* last decision feedback */}
+            {!pending && latestRequest?.status === 'rejected' && (
+              <p className="flex items-start gap-1.5 text-caption text-red-600 dark:text-red-400">
+                <XCircleIcon weight="fill" className="w-4 h-4 shrink-0 mt-0.5" />
+                Your last request was declined{latestRequest.review_note ? `: ${latestRequest.review_note}` : '.'}
+              </p>
+            )}
+            {!pending && latestRequest?.status === 'approved' && (
+              <p className="flex items-center gap-1.5 text-caption text-emerald-600 dark:text-emerald-400">
+                <CheckCircleIcon weight="fill" className="w-4 h-4" /> Your last name change was approved.
+              </p>
+            )}
+
+            {/* request form / trigger */}
+            {!pending &&
+              (showRequest ? (
+                <form onSubmit={submitRequest} className="space-y-3 pt-1">
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label className="text-small-strong text-gray-600 dark:text-gray-300 mb-1.5 block">New first name</label>
+                      <input value={reqFirst} onChange={(e) => setReqFirst(e.target.value)} placeholder="First name" className={fieldClass} />
+                    </div>
+                    <div>
+                      <label className="text-small-strong text-gray-600 dark:text-gray-300 mb-1.5 block">New last name</label>
+                      <input value={reqLast} onChange={(e) => setReqLast(e.target.value)} placeholder="Last name" className={fieldClass} />
+                    </div>
+                  </div>
+                  <div>
+                    <label className="text-small-strong text-gray-600 dark:text-gray-300 mb-1.5 block">Note (optional)</label>
+                    <textarea
+                      value={reqNote}
+                      onChange={(e) => setReqNote(e.target.value)}
+                      rows={2}
+                      placeholder="Reason for the change…"
+                      className={fieldClass}
+                    />
+                  </div>
+                  {reqErr && (
+                    <p className="text-small-strong text-red-500 bg-red-50 dark:bg-red-900/20 rounded-xl px-3 py-2">{reqErr}</p>
+                  )}
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => { setShowRequest(false); setReqErr(null); }}
+                      className="flex-1 px-4 py-2.5 rounded-xl text-small-strong text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="submit"
+                      disabled={busyReq}
+                      className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-small-strong text-white bg-emerald-500 hover:bg-emerald-600 transition-colors disabled:opacity-50"
+                    >
+                      <PaperPlaneTiltIcon weight="bold" className="w-4 h-4" />
+                      {busyReq ? 'Sending…' : 'Send request'}
+                    </button>
+                  </div>
+                </form>
+              ) : (
+                <button
+                  onClick={() => {
+                    setReqFirst(user.first_name ?? '');
+                    setReqLast(user.last_name ?? '');
+                    setReqErr(null);
+                    setShowRequest(true);
+                  }}
+                  className="flex items-center justify-center gap-2 w-full px-4 py-3 rounded-xl text-body-strong text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/15 border border-emerald-100 dark:border-emerald-900/30 hover:bg-emerald-100 dark:hover:bg-emerald-900/25 transition-colors"
+                >
+                  <PaperPlaneTiltIcon weight="bold" className="w-4 h-4" />
+                  Request name change
+                </button>
+              ))}
+          </div>
+        )}
+      </div>
+
       {/* APPEARANCE */}
       <div className="space-y-2">
         <h3 className="px-1 text-label text-gray-400">Appearance</h3>
-        <div className="bg-white dark:bg-gray-800/40 border border-gray-100 dark:border-gray-800 rounded-3xl shadow-sm overflow-hidden">
+        <div className={`${cardClass} overflow-hidden`}>
           <button
             onClick={() => setTheme(isDark ? 'light' : 'dark')}
             className="w-full flex items-center justify-between p-4 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors text-left"
@@ -174,12 +419,8 @@ export default function SettingsPage() {
                 <p className="text-micro text-gray-400">{isDark ? 'Enabled' : 'Disabled'}</p>
               </div>
             </div>
-            <span
-              className={`relative w-11 h-6 rounded-full transition-colors shrink-0 ${isDark ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'}`}
-            >
-              <span
-                className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white transition-transform ${isDark ? 'translate-x-5' : ''}`}
-              />
+            <span className={`relative w-11 h-6 rounded-full transition-colors shrink-0 ${isDark ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'}`}>
+              <span className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white transition-transform ${isDark ? 'translate-x-5' : ''}`} />
             </span>
           </button>
         </div>
@@ -188,7 +429,7 @@ export default function SettingsPage() {
       {/* ACCOUNT (read-only) */}
       <div className="space-y-2">
         <h3 className="px-1 text-label text-gray-400">Account</h3>
-        <div className="bg-white dark:bg-gray-800/40 border border-gray-100 dark:border-gray-800 rounded-3xl shadow-sm overflow-hidden">
+        <div className={`${cardClass} overflow-hidden`}>
           <div className="flex items-center gap-3 p-4 border-b border-gray-50 dark:border-white/5">
             <div className="w-9 h-9 rounded-xl bg-gray-50 dark:bg-gray-900/50 flex items-center justify-center text-gray-500 dark:text-gray-400 shrink-0">
               <EnvelopeSimpleIcon weight="bold" className="w-4 h-4" />

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -75,16 +75,33 @@ export default function SettingsPage() {
     }
   }, [user, isStaff]);
 
+  // Initial load (inline async so we don't call a setState-callback directly in
+  // the effect body). Handlers reuse loadRequest() to refresh after an action.
   useEffect(() => {
-    loadRequest();
-  }, [loadRequest]);
+    if (!user || !isStaff) return;
+    let active = true;
+    (async () => {
+      try {
+        const req = await authService.getMyLatestNameRequest(user.id);
+        if (active) setLatestRequest(req);
+      } catch (err) {
+        console.error('Failed to load name request:', err);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [user, isStaff]);
+
+  // Captured once at mount (clock reads must not happen during render).
+  const [nowTs] = useState(() => Date.now());
 
   if (!user) return null;
 
   // --- username weekly limit ---
   const lastChanged = user.username_changed_at ? new Date(user.username_changed_at).getTime() : null;
   const nextAllowedAt = lastChanged ? lastChanged + WEEK_MS : null;
-  const usernameLocked = nextAllowedAt ? Date.now() < nextAllowedAt : false;
+  const usernameLocked = nextAllowedAt ? nowTs < nextAllowedAt : false;
   const nextAllowedStr = nextAllowedAt
     ? new Date(nextAllowedAt).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
     : '';

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -22,6 +22,37 @@ export const ProfileSchema = z.object({
     rank: z.number().default(0), // Position in the role hierarchy (higher = more privileged)
   }),
   organization_id: z.string(), // The company this user belongs to
+  username_changed_at: z.string().nullable().optional(), // last username change (7-day self-service limit)
+});
+
+/**
+ * NameChangeRequestSchema: an employee's request to change their first/last name.
+ * Staff (rank < 30) cannot edit their own name directly — they file one of these
+ * and an admin approves it (which applies the new name automatically).
+ */
+export const NameChangeRequestSchema = z.object({
+  id: z.string(),
+  user_id: z.string(),
+  organization_id: z.string(),
+  current_first_name: z.string().nullable(),
+  current_last_name: z.string().nullable(),
+  requested_first_name: z.string().nullable(),
+  requested_last_name: z.string().nullable(),
+  note: z.string().nullable().optional(),
+  review_note: z.string().nullable().optional(),
+  status: z.enum(['pending', 'approved', 'rejected']),
+  reviewed_at: z.string().nullable().optional(),
+  created_at: z.string(),
+  // Embedded requester profile (admin list view).
+  requester: z
+    .object({
+      username: z.string(),
+      email: z.email().nullable().optional(),
+      first_name: z.string().nullable().optional(),
+      last_name: z.string().nullable().optional(),
+    })
+    .nullable()
+    .optional(),
 });
 
 /** 
@@ -109,6 +140,7 @@ export type Shift = z.infer<typeof ShiftSchema>;
 export type Location = z.infer<typeof LocationSchema>;
 export type Organization = z.infer<typeof OrganizationSchema>;
 export type Role = z.infer<typeof RoleSchema>;
+export type NameChangeRequest = z.infer<typeof NameChangeRequestSchema>;
 
 /**
  * --- COMPONENT TYPES ---

--- a/supabase/migrations/20260623140000_name_change_requests.sql
+++ b/supabase/migrations/20260623140000_name_change_requests.sql
@@ -1,0 +1,245 @@
+-- =============================================================================
+-- NAME-CHANGE REQUESTS + USERNAME WEEKLY LIMIT
+-- -----------------------------------------------------------------------------
+-- Staff (rank < 30) may no longer change their own first/last name directly —
+-- they submit a request that an admin (rank >= 30, same org) or a Superadmin
+-- approves; approval applies the new name to the profile automatically.
+--
+-- Username stays self-service but is limited to one change every 7 days, for
+-- everyone (tracked via profiles.username_changed_at).
+--
+-- Enforcement is at the database level (a BEFORE UPDATE trigger), so the rules
+-- hold even for direct API calls — the UI only mirrors them.
+-- =============================================================================
+
+-- 1. Track when the username was last changed -------------------------------
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS username_changed_at timestamptz;
+
+-- 2. Requests table ----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.name_change_requests (
+  id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id              uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  organization_id      uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  current_first_name   text,
+  current_last_name    text,
+  requested_first_name text,
+  requested_last_name  text,
+  note                 text,          -- optional message from the requester
+  review_note          text,          -- optional message from the reviewer
+  status               text NOT NULL DEFAULT 'pending'
+                         CHECK (status IN ('pending', 'approved', 'rejected')),
+  reviewed_by          uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  reviewed_at          timestamptz,
+  created_at           timestamptz NOT NULL DEFAULT now()
+);
+
+-- At most one pending request per user.
+CREATE UNIQUE INDEX IF NOT EXISTS one_pending_name_change_per_user
+  ON public.name_change_requests (user_id) WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS name_change_requests_org_status_idx
+  ON public.name_change_requests (organization_id, status);
+
+ALTER TABLE public.name_change_requests ENABLE ROW LEVEL SECURITY;
+
+-- Writes go through SECURITY DEFINER RPCs only; clients get SELECT (under RLS).
+REVOKE ALL              ON public.name_change_requests FROM anon;
+REVOKE INSERT, UPDATE, DELETE ON public.name_change_requests FROM authenticated;
+GRANT  SELECT           ON public.name_change_requests TO authenticated;
+GRANT  ALL              ON public.name_change_requests TO service_role;
+
+-- RLS: requester sees own; admins see their org; superadmin sees everything.
+DROP POLICY IF EXISTS "View own name change requests" ON public.name_change_requests;
+CREATE POLICY "View own name change requests"
+  ON public.name_change_requests FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Admins view org name change requests" ON public.name_change_requests;
+CREATE POLICY "Admins view org name change requests"
+  ON public.name_change_requests FOR SELECT TO authenticated
+  USING (public.my_role_rank() >= 30 AND organization_id = public.get_my_org_id());
+
+DROP POLICY IF EXISTS "Superadmin full access to name change requests" ON public.name_change_requests;
+CREATE POLICY "Superadmin full access to name change requests"
+  ON public.name_change_requests FOR ALL TO authenticated
+  USING (public.is_superadmin()) WITH CHECK (public.is_superadmin());
+
+-- 3. Self-edit enforcement trigger ------------------------------------------
+CREATE OR REPLACE FUNCTION public.enforce_profile_self_edit()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_rank  smallint := public.my_role_rank();
+BEGIN
+  -- NAME: first/last name changes are gated for non-admins (rank < 30).
+  IF (NEW.first_name IS DISTINCT FROM OLD.first_name)
+     OR (NEW.last_name IS DISTINCT FROM OLD.last_name) THEN
+
+    IF OLD.first_name IS NULL AND OLD.last_name IS NULL THEN
+      NULL;  -- onboarding: first-time name entry is allowed
+    ELSIF public.is_superadmin() THEN
+      NULL;  -- superadmin may set any name
+    ELSIF v_actor = NEW.id AND v_rank >= 30 THEN
+      NULL;  -- admins may edit their own name
+    ELSIF v_actor <> NEW.id AND v_rank >= 30
+          AND OLD.organization_id = public.get_my_org_id()
+          AND public.role_rank(OLD.role) < v_rank THEN
+      NULL;  -- admins may edit a lower-ranked member (incl. approving a request)
+    ELSE
+      RAISE EXCEPTION 'Name changes must be requested from an administrator.'
+        USING ERRCODE = 'check_violation';
+    END IF;
+  END IF;
+
+  -- USERNAME: at most one change every 7 days, for everyone.
+  IF NEW.username IS DISTINCT FROM OLD.username THEN
+    IF OLD.username_changed_at IS NOT NULL
+       AND now() - OLD.username_changed_at < interval '7 days' THEN
+      RAISE EXCEPTION
+        'You can only change your username once every 7 days. Next change available after %.',
+        to_char(OLD.username_changed_at + interval '7 days', 'YYYY-MM-DD HH24:MI UTC')
+        USING ERRCODE = 'check_violation';
+    END IF;
+    NEW.username_changed_at := now();
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.enforce_profile_self_edit() FROM PUBLIC, anon, authenticated;
+
+DROP TRIGGER IF EXISTS enforce_profile_self_edit_trigger ON public.profiles;
+CREATE TRIGGER enforce_profile_self_edit_trigger
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION public.enforce_profile_self_edit();
+
+-- 4. RPC: submit a name-change request --------------------------------------
+CREATE OR REPLACE FUNCTION public.request_name_change(
+  p_first_name text,
+  p_last_name  text,
+  p_note       text DEFAULT NULL
+) RETURNS public.name_change_requests
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_uid     uuid := auth.uid();
+  v_profile public.profiles%ROWTYPE;
+  v_first   text := NULLIF(btrim(p_first_name), '');
+  v_last    text := NULLIF(btrim(p_last_name), '');
+  v_row     public.name_change_requests;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated.' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF v_first IS NULL AND v_last IS NULL THEN
+    RAISE EXCEPTION 'Provide a first and/or last name.' USING ERRCODE = 'check_violation';
+  END IF;
+
+  SELECT * INTO v_profile FROM public.profiles WHERE id = v_uid;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Profile not found.' USING ERRCODE = 'no_data_found';
+  END IF;
+
+  -- Fall back to the current value for any field the requester left blank.
+  v_first := COALESCE(v_first, v_profile.first_name);
+  v_last  := COALESCE(v_last,  v_profile.last_name);
+
+  IF v_first IS NOT DISTINCT FROM v_profile.first_name
+     AND v_last IS NOT DISTINCT FROM v_profile.last_name THEN
+    RAISE EXCEPTION 'The requested name matches your current name.' USING ERRCODE = 'check_violation';
+  END IF;
+
+  INSERT INTO public.name_change_requests (
+    user_id, organization_id,
+    current_first_name, current_last_name,
+    requested_first_name, requested_last_name, note
+  ) VALUES (
+    v_uid, v_profile.organization_id,
+    v_profile.first_name, v_profile.last_name,
+    v_first, v_last, NULLIF(btrim(p_note), '')
+  )
+  RETURNING * INTO v_row;
+
+  RETURN v_row;
+EXCEPTION
+  WHEN unique_violation THEN
+    RAISE EXCEPTION 'You already have a pending name change request.' USING ERRCODE = 'unique_violation';
+END;
+$$;
+
+REVOKE ALL  ON FUNCTION public.request_name_change(text, text, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.request_name_change(text, text, text) TO authenticated;
+
+-- 5. RPC: cancel your own pending request -----------------------------------
+CREATE OR REPLACE FUNCTION public.cancel_name_change_request(p_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_deleted int;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated.' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  DELETE FROM public.name_change_requests
+   WHERE id = p_id AND user_id = v_uid AND status = 'pending';
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted > 0;
+END;
+$$;
+
+REVOKE ALL  ON FUNCTION public.cancel_name_change_request(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.cancel_name_change_request(uuid) TO authenticated;
+
+-- 6. RPC: approve / reject a request (admins same org, or superadmin) --------
+CREATE OR REPLACE FUNCTION public.review_name_change_request(
+  p_id          uuid,
+  p_approve     boolean,
+  p_review_note text DEFAULT NULL
+) RETURNS public.name_change_requests
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_uid  uuid := auth.uid();
+  v_rank smallint := public.my_role_rank();
+  v_req  public.name_change_requests;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated.' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  SELECT * INTO v_req FROM public.name_change_requests WHERE id = p_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Request not found.' USING ERRCODE = 'no_data_found';
+  END IF;
+  IF v_req.status <> 'pending' THEN
+    RAISE EXCEPTION 'This request has already been reviewed.' USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Superadmin anywhere; otherwise admin (>= 30) within the same organization.
+  IF NOT public.is_superadmin() THEN
+    IF v_rank < 30 OR v_req.organization_id <> public.get_my_org_id() THEN
+      RAISE EXCEPTION 'You are not allowed to review this request.'
+        USING ERRCODE = 'insufficient_privilege';
+    END IF;
+  END IF;
+
+  IF p_approve THEN
+    UPDATE public.profiles
+       SET first_name = v_req.requested_first_name,
+           last_name  = v_req.requested_last_name
+     WHERE id = v_req.user_id;
+  END IF;
+
+  UPDATE public.name_change_requests
+     SET status      = CASE WHEN p_approve THEN 'approved' ELSE 'rejected' END,
+         review_note = NULLIF(btrim(p_review_note), ''),
+         reviewed_by = v_uid,
+         reviewed_at = now()
+   WHERE id = p_id
+   RETURNING * INTO v_req;
+
+  RETURN v_req;
+END;
+$$;
+
+REVOKE ALL  ON FUNCTION public.review_name_change_request(uuid, boolean, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.review_name_change_request(uuid, boolean, text) TO authenticated;


### PR DESCRIPTION
## What

Staff can no longer rename themselves at will, and username changes are rate-limited.

- **Names (first/last):** staff (rank < 30) can't edit their own name directly — they file a request that an **admin (rank ≥ 30, same org)** or a **Superadmin** approves. Approval applies the new name automatically.
- **Username:** stays self-service but limited to **one change every 7 days**, for everyone.
- **Onboarding:** the invitee can still set their name once on accept-invite (when it's still empty).

## Enforcement (DB-level, holds for direct API calls)

- `name_change_requests` table — RLS: requester sees own, admins see their org, Superadmin sees all; **writes only via `SECURITY DEFINER` RPCs**; partial unique index = one pending request per user.
- `profiles.username_changed_at` + `BEFORE UPDATE` trigger `enforce_profile_self_edit` (gates name edits by rank; enforces the 7-day username rule).
- RPCs: `request_name_change`, `cancel_name_change_request`, `review_name_change_request`.

## Frontend

- **Settings:** Username section with the weekly-limit notice; staff get a read-only name + a "Request name change" flow (with pending/approved/rejected status and cancel); admins edit their name directly.
- **Admin Panel:** new **Requests** tab (admins only) to approve/reject, with a pending-count badge.

## Rollout / verification

- Migration applied to **prod + preprod**; verified with a transactional test: employee self-rename **blocked**, username **7-day** limit enforced, admin/superadmin rename **allowed**, RPC submit **OK**.
- Already pushed to `preview` for testing at **dev-planuj-smeny.vercel.app**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaA2yRDjYQTyeGsCto9WLp)_