### PR TITLE
feat(ui): Google-style mobile menu + redesigned location popup

### DIFF
--- a/src/app/layout/AppShell.tsx
+++ b/src/app/layout/AppShell.tsx
@@ -9,7 +9,7 @@ import { useLocationManagement } from '@features/locations/hooks/useLocationMana
 
 import { Dashboard } from '@features/dashboard/Dashboard';
 import { BottomNav } from './BottomNav';
-import { LocationPopup } from '@features/locations/components/LocationPopup';
+import { LocationPopup, type LocationPopupVariant } from '@features/locations/components/LocationPopup';
 import { type User, type Shift, type Location } from '@shared/types';
 
 /**
@@ -36,7 +36,7 @@ export interface AppOutletContext {
 
 export function AppShell() {
   const { user, isAuthChecking, isLoading: isAuthLoading } = useAuthContext();
-  const { activeShift, allActiveShifts, locations, selectedLocationId, setSelectedLocationId, actionError, clearActionError } = useShiftContext();
+  const { activeShift, allActiveShifts, locations, selectedLocationId, setSelectedLocationId, handleChangeLocation, isChangingLocation, actionError, clearActionError } = useShiftContext();
 
   // Auto-dismiss the shift-action error toast after a few seconds.
   useEffect(() => {
@@ -49,6 +49,25 @@ export function AppShell() {
   const { isLocationPopupOpen, setIsLocationPopupOpen, pendingLocation, handleLocationSelect } = useLocationManagement({
     locations, activeShift, selectedLocationId, setSelectedLocationId,
   });
+
+  // What the location popup is asking, and what confirming does.
+  const popupVariant: LocationPopupVariant = !pendingLocation
+    ? 'confirm'
+    : pendingLocation.id === selectedLocationId
+      ? 'same'
+      : activeShift
+        ? 'switch'
+        : 'confirm';
+
+  const confirmLocation = async () => {
+    if (!pendingLocation) return;
+    if (activeShift && selectedLocationId && selectedLocationId !== pendingLocation.id) {
+      await handleChangeLocation(pendingLocation.id); // persist the move on the active shift
+    } else if (pendingLocation.id !== selectedLocationId) {
+      setSelectedLocationId(pendingLocation.id); // just pick where to clock in
+    }
+    setIsLocationPopupOpen(false);
+  };
 
   // 1. GLOBAL LOADING: Only show a full-page spinner during initial auth check or if no user is present.
   // We avoid unmounting the whole AppShell when shifts are refreshing in the background (flicker fix).
@@ -109,11 +128,11 @@ export function AppShell() {
       <AnimatePresence>
         {isLocationPopupOpen && pendingLocation && (
           <LocationPopup
-            isChangedLocation={{ selectedLocationId, pendingLocationId: pendingLocation.id }}
-            location={pendingLocation}
-            setIsLocationPopupOpen={setIsLocationPopupOpen}
-            setSelectedLocationId={setSelectedLocationId}
-            handleChangeLocation={() => { }}
+            locationName={pendingLocation.name}
+            variant={popupVariant}
+            isBusy={isChangingLocation}
+            onConfirm={confirmLocation}
+            onCancel={() => setIsLocationPopupOpen(false)}
           />
         )}
       </AnimatePresence>

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Link, useLocation } from 'react-router-dom';
-import { SquaresFourIcon, ChartBarIcon, GearIcon, ShieldCheckIcon } from "@phosphor-icons/react";
+import { SquaresFourIcon, ChartBarIcon, GearIcon, ShieldCheckIcon, ListIcon, XIcon, SignOutIcon, CaretRightIcon, PaletteIcon } from "@phosphor-icons/react";
 
 import { Clock } from '@shared/components/Clock';
 import { useAuthContext } from '@features/auth/AuthContext';
@@ -39,8 +39,23 @@ export function Dashboard({ onLocationSelect }: DashboardProps) {
   ];
 
   const { setTheme, resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
   const [searchQuery, setSearchQuery] = useState('');
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const currentRoute = useLocation();
+
+  // Lock background scroll while the mobile menu sheet is open.
+  useEffect(() => {
+    document.body.style.overflow = isMenuOpen ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isMenuOpen]);
+
+  const fullName =
+    user && (user.first_name || user.last_name)
+      ? `${user.first_name ?? ''} ${user.last_name ?? ''}`.trim()
+      : user?.username ?? '';
 
   const filteredLocations = locations.filter(loc =>
     // hide archived, but keep the one you're currently clocked into
@@ -74,12 +89,8 @@ export function Dashboard({ onLocationSelect }: DashboardProps) {
               <div className="text-xl font-bold text-gray-800 dark:text-white tracking-tight"><Clock seconds={false} /></div>
             </div>
 
-            <button onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')} className="md:hidden -mr-2 p-2 rounded-xl text-gray-600 dark:text-gray-300 hover:bg-emerald-500/5 dark:hover:bg-white/5 transition-all cursor-pointer active:scale-90 z-10" aria-label="Toggle theme">
-              <AnimatePresence mode="wait" initial={false}>
-                <motion.div key={resolvedTheme} initial={{ y: -5, opacity: 0, rotate: -45 }} animate={{ y: 0, opacity: 1, rotate: 0 }} exit={{ y: 5, opacity: 0, rotate: 45 }} transition={{ duration: 0.2 }}>
-                  {resolvedTheme === 'dark' ? <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-7 h-7"><path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M3 12h2.25m.386-6.364l-1.591 1.591M12 7.5a4.5 4.5 0 110 9 4.5 4.5 0 010-9z" /></svg> : <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-7 h-7"><path strokeLinecap="round" strokeLinejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" /></svg>}
-                </motion.div>
-              </AnimatePresence>
+            <button onClick={() => setIsMenuOpen(true)} className="md:hidden -mr-2 p-2 rounded-xl text-gray-700 dark:text-gray-200 hover:bg-emerald-500/5 dark:hover:bg-white/5 transition-all cursor-pointer active:scale-90 z-10" aria-label="Open menu">
+              <ListIcon weight="bold" className="w-7 h-7" />
             </button>
           </div>
 
@@ -163,6 +174,99 @@ export function Dashboard({ onLocationSelect }: DashboardProps) {
           </div>
         </div>
       </header>
+
+      {/* --- MOBILE "MORE" MENU (sheet over the app) --- */}
+      <AnimatePresence>
+        {isMenuOpen && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="fixed inset-0 z-[100] md:hidden bg-black/40 backdrop-blur-sm"
+            onClick={() => setIsMenuOpen(false)}
+          >
+            <motion.aside
+              initial={{ x: '100%' }}
+              animate={{ x: 0 }}
+              exit={{ x: '100%' }}
+              transition={{ type: 'spring', stiffness: 380, damping: 38 }}
+              onClick={(e) => e.stopPropagation()}
+              className="absolute right-0 top-0 h-dvh w-[88%] max-w-sm flex flex-col bg-white/95 dark:bg-gray-900/95 backdrop-blur-xl border-l border-gray-100 dark:border-white/10 shadow-2xl"
+            >
+              {/* Header — just "Menu", no logo */}
+              <div className="flex items-center justify-between px-5 h-14 shrink-0 border-b border-gray-100 dark:border-white/5 pt-[env(safe-area-inset-top)]">
+                <h2 className="text-title text-gray-900 dark:text-white">Menu</h2>
+                <button
+                  onClick={() => setIsMenuOpen(false)}
+                  aria-label="Close menu"
+                  className="-mr-2 p-2 rounded-xl text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-white/5 transition-colors active:scale-90"
+                >
+                  <XIcon weight="bold" className="w-5 h-5" />
+                </button>
+              </div>
+
+              {/* Scrollable content */}
+              <div className="flex-1 overflow-y-auto p-4 space-y-4">
+                {/* Profile */}
+                {user && (
+                  <div className="flex items-center gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-white/5 border border-gray-100 dark:border-white/5">
+                    <div className="w-14 h-14 rounded-full bg-emerald-100 dark:bg-emerald-900/40 border-2 border-white dark:border-white/10 shadow-md flex items-center justify-center text-emerald-700 dark:text-emerald-400 text-title shrink-0">
+                      {getInitials(user.first_name, user.last_name)}
+                    </div>
+                    <div className="min-w-0">
+                      <p className="text-body-strong text-gray-900 dark:text-white truncate">{fullName}</p>
+                      <p className="text-caption text-gray-500 dark:text-gray-400 truncate">{user.email}</p>
+                      <p className="text-micro text-emerald-600 dark:text-emerald-400 truncate normal-case">@{user.username}</p>
+                    </div>
+                  </div>
+                )}
+
+                {/* Services */}
+                <div className="rounded-2xl bg-gray-50 dark:bg-white/5 border border-gray-100 dark:border-white/5 overflow-hidden">
+                  <Link
+                    to="/settings"
+                    onClick={() => setIsMenuOpen(false)}
+                    className="flex items-center gap-3 p-4 hover:bg-gray-100 dark:hover:bg-white/5 transition-colors"
+                  >
+                    <div className="w-9 h-9 rounded-xl bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 dark:text-emerald-400 flex items-center justify-center shrink-0">
+                      <GearIcon weight="bold" className="w-4 h-4" />
+                    </div>
+                    <span className="flex-1 text-body-strong text-gray-900 dark:text-white">Settings</span>
+                    <CaretRightIcon weight="bold" className="w-4 h-4 text-gray-400" />
+                  </Link>
+
+                  <div className="border-t border-gray-100 dark:border-white/5" />
+
+                  <button
+                    onClick={() => setTheme(isDark ? 'light' : 'dark')}
+                    className="w-full flex items-center gap-3 p-4 hover:bg-gray-100 dark:hover:bg-white/5 transition-colors text-left"
+                  >
+                    <div className="w-9 h-9 rounded-xl bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 flex items-center justify-center shrink-0">
+                      <PaletteIcon weight="bold" className="w-4 h-4" />
+                    </div>
+                    <span className="flex-1 text-body-strong text-gray-900 dark:text-white">Dark mode</span>
+                    <span className={`relative w-11 h-6 rounded-full transition-colors shrink-0 ${isDark ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'}`}>
+                      <span className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white transition-transform ${isDark ? 'translate-x-5' : ''}`} />
+                    </span>
+                  </button>
+                </div>
+              </div>
+
+              {/* Pinned logout */}
+              <div className="shrink-0 p-4 pb-[calc(1rem+env(safe-area-inset-bottom))] border-t border-gray-100 dark:border-white/5">
+                <button
+                  onClick={logout}
+                  className="flex w-full items-center justify-center gap-2 py-3.5 rounded-2xl text-body-strong text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/10 border border-red-100 dark:border-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/20 active:scale-[0.99] transition-all"
+                >
+                  <SignOutIcon weight="bold" className="w-5 h-5" />
+                  Log out
+                </button>
+              </div>
+            </motion.aside>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </>
   );
 }

--- a/src/features/locations/components/LocationPopup.tsx
+++ b/src/features/locations/components/LocationPopup.tsx
@@ -1,88 +1,48 @@
-import React from 'react';
-import { motion, type Variants } from 'framer-motion';
-import { type Location } from '@shared/types';
-import { useShiftContext } from '@features/shifts/ShiftContext';
+import { motion } from 'framer-motion';
+import { MapPinIcon, ArrowsLeftRightIcon, InfoIcon, type Icon } from '@phosphor-icons/react';
 
 /**
- * --- LOCATION POPUP COMPONENT ---
- * Modal to confirm location choice or location change.
- * This popup asks the user: "Are you sure you want to select [Location Name]?"
+ * --- LOCATION POPUP ---
+ * Confirms picking / switching a work location. Purely presentational — the
+ * parent (AppShell) owns the state and the confirm action. Big, well-separated
+ * buttons so OK / Cancel are hard to mis-tap on a phone, styled like the rest
+ * of the app (bottom sheet on mobile, centered card on desktop).
  */
 
+export type LocationPopupVariant = 'confirm' | 'switch' | 'same';
+
 export interface LocationPopupProps {
-    isChangedLocation: {
-        selectedLocationId: string | null;
-        pendingLocationId: string | null;
-    };
-    location: Location | null;
-    setIsLocationPopupOpen: (open: boolean) => void;
-    setSelectedLocationId: React.Dispatch<React.SetStateAction<string | null>>;
-    handleChangeLocation: (change: boolean) => void;
+    locationName: string;
+    variant: LocationPopupVariant;
+    isBusy: boolean;
+    onConfirm: () => void;
+    onCancel: () => void;
 }
 
-export function LocationPopup({
-    isChangedLocation,
-    location,
-    setIsLocationPopupOpen,
-    setSelectedLocationId,
-    handleChangeLocation,
-}: LocationPopupProps) {
-    const { activeShift, handleChangeLocation: updateShiftLocation, isChangingLocation } = useShiftContext();
-    const { selectedLocationId, pendingLocationId } = isChangedLocation;
-    
-    // logic variables to determine the state
-    const isSwitch = selectedLocationId != null && pendingLocationId != null;
-    const isSameLocation = selectedLocationId === pendingLocationId;
+const COPY: Record<LocationPopupVariant, { title: string; sub: string; icon: Icon; tint: string }> = {
+    confirm: {
+        title: 'Start here?',
+        sub: 'Set your location to',
+        icon: MapPinIcon,
+        tint: 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400',
+    },
+    switch: {
+        title: 'Move your shift?',
+        sub: 'Change your location to',
+        icon: ArrowsLeftRightIcon,
+        tint: 'bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400',
+    },
+    same: {
+        title: "You're already here",
+        sub: 'Your current location',
+        icon: InfoIcon,
+        tint: 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400',
+    },
+};
 
-    const handleConfirm = async () => {
-        if (!location?.id) return;
-        
-        // If we have an active shift, we MUST update it on the server too.
-        if (activeShift && isSwitch && selectedLocationId !== pendingLocationId) {
-            await updateShiftLocation(location.id);
-        } else {
-            // Otherwise just update the frontend selection.
-            setSelectedLocationId(location.id);
-        }
-        
-        // 2. Close the modal.
-        setIsLocationPopupOpen(false);
-
-        // 3. Optional: Trigger specific "location changed" logic.
-        if (isSwitch && selectedLocationId !== pendingLocationId) {
-            handleChangeLocation(true);
-        }
-    };
-
-    const handleCancel = () => setIsLocationPopupOpen(false);
-
-    // Determine titles and colors based on whether we are selecting for the first time or switching.
-    const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
-
-    const popupVariants: Variants = {
-        hidden: isMobile
-            ? { y: "100%", opacity: 0.5 }
-            : { scale: 0.9, opacity: 0, y: 0 },
-        visible: {
-            y: 0, scale: 1, opacity: 1,
-            transition: { type: "spring", bounce: 0.3, duration: 0.5 }
-        },
-        exit: isMobile
-            ? { y: "100%", opacity: 0, transition: { duration: 0.2, ease: "easeIn" } }
-            : { scale: 0.9, opacity: 0, transition: { duration: 0.2, ease: "easeIn" } }
-    };
-
-    const title = isSameLocation
-        ? 'You are already at this location.'
-        : isSwitch
-            ? 'Change Location?'
-            : 'Confirm Location?';
-    
-    const titleClass = isSameLocation
-        ? 'text-red-600 dark:text-red-400'
-        : isSwitch
-            ? 'text-amber-600 dark:text-amber-400'
-            : 'text-emerald-600 dark:text-emerald-400';
+export function LocationPopup({ locationName, variant, isBusy, onConfirm, onCancel }: LocationPopupProps) {
+    const { title, sub, icon: VariantIcon, tint } = COPY[variant];
+    const isSame = variant === 'same';
 
     return (
         <motion.div
@@ -90,47 +50,58 @@ export function LocationPopup({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="fixed inset-0 z-100 flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm p-0 sm:p-4"
-            onClick={handleCancel}
+            className="fixed inset-0 z-[100] flex items-end sm:items-center justify-center bg-black/50 backdrop-blur-sm p-0 sm:p-4"
+            onClick={onCancel}
         >
             <motion.div
-                variants={popupVariants}
-                initial="hidden"
-                animate="visible"
-                exit="exit"
-                onClick={(e) => e.stopPropagation()} // Stop click from bubbling to the backdrop (so it doesn't close)
-                className="bg-white dark:bg-gray-900 p-6 sm:rounded-2xl rounded-t-3xl shadow-xl w-full max-w-md transition-colors"
+                initial={{ y: '100%', opacity: 0.6, scale: 1 }}
+                animate={{ y: 0, opacity: 1, scale: 1 }}
+                exit={{ y: '100%', opacity: 0 }}
+                transition={{ type: 'spring', stiffness: 360, damping: 32 }}
+                onClick={(e) => e.stopPropagation()}
+                className="w-full max-w-md bg-white dark:bg-gray-900 rounded-t-3xl sm:rounded-3xl border border-gray-100 dark:border-gray-800 shadow-2xl p-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))] sm:pb-6"
             >
-                <h2 className={`text-3xl md:text-2xl font-bold mb-4 ${titleClass}`}>{title}</h2>
-                <h3 className="text-lg font-semibold text-gray-700 dark:text-gray-300">{location?.name}</h3>
+                {/* Grab handle (mobile bottom-sheet affordance) */}
+                <div className="sm:hidden mx-auto mb-5 h-1.5 w-10 rounded-full bg-gray-200 dark:bg-gray-700" />
 
-                <div className="flex justify-end space-x-3 mt-6">
-                    {!isSameLocation ? (
+                <div className="flex flex-col items-center text-center">
+                    <div className={`w-14 h-14 rounded-2xl flex items-center justify-center ${tint}`}>
+                        <VariantIcon weight="bold" className="w-7 h-7" />
+                    </div>
+                    <h2 className="text-title text-gray-900 dark:text-white mt-4">{title}</h2>
+                    <p className="text-micro text-gray-400 mt-3">{sub}</p>
+                    <p className="text-heading text-gray-900 dark:text-white mt-1">{locationName}</p>
+                </div>
+
+                <div className={`mt-7 ${isSame ? '' : 'flex gap-3'}`}>
+                    {isSame ? (
+                        <button
+                            type="button"
+                            onClick={onCancel}
+                            className="w-full py-4 rounded-2xl text-body-strong text-white bg-linear-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 shadow-lg shadow-emerald-500/25 active:scale-[0.98] transition-all"
+                        >
+                            Got it
+                        </button>
+                    ) : (
                         <>
                             <button
                                 type="button"
-                                onClick={handleCancel}
-                                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+                                onClick={onCancel}
+                                disabled={isBusy}
+                                className="flex-1 py-4 rounded-2xl text-body-strong text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 active:scale-[0.98] disabled:opacity-50 transition-all"
                             >
                                 Cancel
                             </button>
                             <button
                                 type="button"
-                                onClick={handleConfirm}
-                                disabled={isChangingLocation}
-                                className="px-4 py-2 text-sm font-medium text-white bg-emerald-600 rounded-md hover:bg-emerald-700 transition-colors shadow-sm cursor-pointer disabled:opacity-50"
+                                onClick={onConfirm}
+                                disabled={isBusy}
+                                className="flex-1 flex items-center justify-center gap-2 py-4 rounded-2xl text-body-strong text-white bg-linear-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 shadow-lg shadow-emerald-500/25 active:scale-[0.98] disabled:opacity-70 disabled:active:scale-100 transition-all"
                             >
-                                {isChangingLocation ? 'Updating...' : 'Yes'}
+                                {isBusy && <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />}
+                                {isBusy ? 'Saving…' : 'Confirm'}
                             </button>
                         </>
-                    ) : (
-                        <button
-                            type="button"
-                            onClick={handleCancel}
-                            className="px-4 py-2 text-sm font-medium text-white bg-emerald-600 rounded-md hover:bg-emerald-700 transition-colors shadow-sm cursor-pointer"
-                        >
-                            Got it
-                        </button>
                     )}
                 </div>
             </motion.div>

--- a/src/features/locations/hooks/useLocationManagement.ts
+++ b/src/features/locations/hooks/useLocationManagement.ts
@@ -34,7 +34,9 @@ export function useLocationManagement({
     // 1. Same location clicked
     if (locationId === selectedLocationId) {
       if (activeShift) {
-        setIsLocationPopupOpen(true); // Let them know they are already here.
+        // Let them know they're already here (popup needs the location to show).
+        setPendingLocation(locations.find((loc) => loc.id === locationId) ?? null);
+        setIsLocationPopupOpen(true);
       } else {
         setSelectedLocationId(null); // Deselect if no active shift.
       }

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -5,7 +5,6 @@ import {
   EnvelopeSimpleIcon,
   IdentificationBadgeIcon,
   CheckCircleIcon,
-  SignOutIcon,
 } from '@phosphor-icons/react';
 import { useAuthContext } from '@features/auth/AuthContext';
 import { authService } from '@features/auth/authService';
@@ -22,7 +21,7 @@ import { getRoleBadgeColor } from '@shared/utils/roleColors';
 const USERNAME_RE = /^[a-z0-9._-]{3,30}$/;
 
 export default function SettingsPage() {
-  const { user, refreshUser, logout } = useAuthContext();
+  const { user, refreshUser } = useAuthContext();
   const { resolvedTheme, setTheme } = useTheme();
   const isDark = resolvedTheme === 'dark';
 
@@ -209,15 +208,6 @@ export default function SettingsPage() {
           </div>
         </div>
       </div>
-
-      {/* LOG OUT */}
-      <button
-        onClick={logout}
-        className="flex w-full items-center justify-center gap-2 py-3.5 rounded-2xl text-body-strong text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/10 border border-red-100 dark:border-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/20 active:scale-[0.99] transition-all"
-      >
-        <SignOutIcon weight="bold" className="w-5 h-5" />
-        Log out
-      </button>
 
       <div className="pt-2 text-center">
         <p className="text-micro text-gray-300 dark:text-gray-600">Version 1.0.4 • 2026</p>


### PR DESCRIPTION
Two UI requests.

**Mobile 'more' menu** (was missing/empty) — a right-side sheet over a dimmed+blurred backdrop so it clearly sits *above* the app:
- Header is just **Menu** (no logo) with a close button.
- **Profile** card: avatar, full name, email, @username.
- **Services** section (Google-style): Settings link + Dark mode toggle.
- **Log out** pinned at the bottom — moved here out of Settings.
- The mobile top-bar theme toggle is replaced by the hamburger (theme lives in the menu now).

**Location popup** — rewritten as a pure presentational bottom sheet matching the app's design: large full-width **Cancel / Confirm** buttons with a clear gap (hard to mis-tap), variant-aware copy/icon (*Start here?* / *Move your shift?* / *You're already here*). AppShell owns the confirm logic; the 'already here' case now passes the location so the popup renders.

Verified on mobile in a temp harness: popup (all variants) + menu (profile/services/logout, dimmed backdrop). typecheck/lint/test/build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)