### PR TITLE
feat(ui): redesign location confirm/switch popup

### DIFF
--- a/src/app/layout/AppShell.tsx
+++ b/src/app/layout/AppShell.tsx
@@ -9,7 +9,7 @@ import { useLocationManagement } from '@features/locations/hooks/useLocationMana
 
 import { Dashboard } from '@features/dashboard/Dashboard';
 import { BottomNav } from './BottomNav';
-import { LocationPopup } from '@features/locations/components/LocationPopup';
+import { LocationPopup, type LocationPopupVariant } from '@features/locations/components/LocationPopup';
 import { type User, type Shift, type Location } from '@shared/types';
 
 /**
@@ -36,7 +36,7 @@ export interface AppOutletContext {
 
 export function AppShell() {
   const { user, isAuthChecking, isLoading: isAuthLoading } = useAuthContext();
-  const { activeShift, allActiveShifts, locations, selectedLocationId, setSelectedLocationId, actionError, clearActionError } = useShiftContext();
+  const { activeShift, allActiveShifts, locations, selectedLocationId, setSelectedLocationId, handleChangeLocation, isChangingLocation, actionError, clearActionError } = useShiftContext();
 
   // Auto-dismiss the shift-action error toast after a few seconds.
   useEffect(() => {
@@ -49,6 +49,25 @@ export function AppShell() {
   const { isLocationPopupOpen, setIsLocationPopupOpen, pendingLocation, handleLocationSelect } = useLocationManagement({
     locations, activeShift, selectedLocationId, setSelectedLocationId,
   });
+
+  // What the location popup is asking, and what confirming does.
+  const popupVariant: LocationPopupVariant = !pendingLocation
+    ? 'confirm'
+    : pendingLocation.id === selectedLocationId
+      ? 'same'
+      : activeShift
+        ? 'switch'
+        : 'confirm';
+
+  const confirmLocation = async () => {
+    if (!pendingLocation) return;
+    if (activeShift && selectedLocationId && selectedLocationId !== pendingLocation.id) {
+      await handleChangeLocation(pendingLocation.id); // persist the move on the active shift
+    } else if (pendingLocation.id !== selectedLocationId) {
+      setSelectedLocationId(pendingLocation.id); // just pick where to clock in
+    }
+    setIsLocationPopupOpen(false);
+  };
 
   // 1. GLOBAL LOADING: Only show a full-page spinner during initial auth check or if no user is present.
   // We avoid unmounting the whole AppShell when shifts are refreshing in the background (flicker fix).
@@ -109,11 +128,11 @@ export function AppShell() {
       <AnimatePresence>
         {isLocationPopupOpen && pendingLocation && (
           <LocationPopup
-            isChangedLocation={{ selectedLocationId, pendingLocationId: pendingLocation.id }}
-            location={pendingLocation}
-            setIsLocationPopupOpen={setIsLocationPopupOpen}
-            setSelectedLocationId={setSelectedLocationId}
-            handleChangeLocation={() => { }}
+            locationName={pendingLocation.name}
+            variant={popupVariant}
+            isBusy={isChangingLocation}
+            onConfirm={confirmLocation}
+            onCancel={() => setIsLocationPopupOpen(false)}
           />
         )}
       </AnimatePresence>

--- a/src/features/locations/components/LocationPopup.tsx
+++ b/src/features/locations/components/LocationPopup.tsx
@@ -1,88 +1,48 @@
-import React from 'react';
-import { motion, type Variants } from 'framer-motion';
-import { type Location } from '@shared/types';
-import { useShiftContext } from '@features/shifts/ShiftContext';
+import { motion } from 'framer-motion';
+import { MapPinIcon, ArrowsLeftRightIcon, InfoIcon, type Icon } from '@phosphor-icons/react';
 
 /**
- * --- LOCATION POPUP COMPONENT ---
- * Modal to confirm location choice or location change.
- * This popup asks the user: "Are you sure you want to select [Location Name]?"
+ * --- LOCATION POPUP ---
+ * Confirms picking / switching a work location. Purely presentational — the
+ * parent (AppShell) owns the state and the confirm action. Big, well-separated
+ * buttons so OK / Cancel are hard to mis-tap on a phone, styled like the rest
+ * of the app (bottom sheet on mobile, centered card on desktop).
  */
 
+export type LocationPopupVariant = 'confirm' | 'switch' | 'same';
+
 export interface LocationPopupProps {
-    isChangedLocation: {
-        selectedLocationId: string | null;
-        pendingLocationId: string | null;
-    };
-    location: Location | null;
-    setIsLocationPopupOpen: (open: boolean) => void;
-    setSelectedLocationId: React.Dispatch<React.SetStateAction<string | null>>;
-    handleChangeLocation: (change: boolean) => void;
+    locationName: string;
+    variant: LocationPopupVariant;
+    isBusy: boolean;
+    onConfirm: () => void;
+    onCancel: () => void;
 }
 
-export function LocationPopup({
-    isChangedLocation,
-    location,
-    setIsLocationPopupOpen,
-    setSelectedLocationId,
-    handleChangeLocation,
-}: LocationPopupProps) {
-    const { activeShift, handleChangeLocation: updateShiftLocation, isChangingLocation } = useShiftContext();
-    const { selectedLocationId, pendingLocationId } = isChangedLocation;
-    
-    // logic variables to determine the state
-    const isSwitch = selectedLocationId != null && pendingLocationId != null;
-    const isSameLocation = selectedLocationId === pendingLocationId;
+const COPY: Record<LocationPopupVariant, { title: string; sub: string; icon: Icon; tint: string }> = {
+    confirm: {
+        title: 'Start here?',
+        sub: 'Set your location to',
+        icon: MapPinIcon,
+        tint: 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400',
+    },
+    switch: {
+        title: 'Move your shift?',
+        sub: 'Change your location to',
+        icon: ArrowsLeftRightIcon,
+        tint: 'bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400',
+    },
+    same: {
+        title: "You're already here",
+        sub: 'Your current location',
+        icon: InfoIcon,
+        tint: 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400',
+    },
+};
 
-    const handleConfirm = async () => {
-        if (!location?.id) return;
-        
-        // If we have an active shift, we MUST update it on the server too.
-        if (activeShift && isSwitch && selectedLocationId !== pendingLocationId) {
-            await updateShiftLocation(location.id);
-        } else {
-            // Otherwise just update the frontend selection.
-            setSelectedLocationId(location.id);
-        }
-        
-        // 2. Close the modal.
-        setIsLocationPopupOpen(false);
-
-        // 3. Optional: Trigger specific "location changed" logic.
-        if (isSwitch && selectedLocationId !== pendingLocationId) {
-            handleChangeLocation(true);
-        }
-    };
-
-    const handleCancel = () => setIsLocationPopupOpen(false);
-
-    // Determine titles and colors based on whether we are selecting for the first time or switching.
-    const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
-
-    const popupVariants: Variants = {
-        hidden: isMobile
-            ? { y: "100%", opacity: 0.5 }
-            : { scale: 0.9, opacity: 0, y: 0 },
-        visible: {
-            y: 0, scale: 1, opacity: 1,
-            transition: { type: "spring", bounce: 0.3, duration: 0.5 }
-        },
-        exit: isMobile
-            ? { y: "100%", opacity: 0, transition: { duration: 0.2, ease: "easeIn" } }
-            : { scale: 0.9, opacity: 0, transition: { duration: 0.2, ease: "easeIn" } }
-    };
-
-    const title = isSameLocation
-        ? 'You are already at this location.'
-        : isSwitch
-            ? 'Change Location?'
-            : 'Confirm Location?';
-    
-    const titleClass = isSameLocation
-        ? 'text-red-600 dark:text-red-400'
-        : isSwitch
-            ? 'text-amber-600 dark:text-amber-400'
-            : 'text-emerald-600 dark:text-emerald-400';
+export function LocationPopup({ locationName, variant, isBusy, onConfirm, onCancel }: LocationPopupProps) {
+    const { title, sub, icon: VariantIcon, tint } = COPY[variant];
+    const isSame = variant === 'same';
 
     return (
         <motion.div
@@ -90,47 +50,58 @@ export function LocationPopup({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="fixed inset-0 z-100 flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm p-0 sm:p-4"
-            onClick={handleCancel}
+            className="fixed inset-0 z-[100] flex items-end sm:items-center justify-center bg-black/50 backdrop-blur-sm p-0 sm:p-4"
+            onClick={onCancel}
         >
             <motion.div
-                variants={popupVariants}
-                initial="hidden"
-                animate="visible"
-                exit="exit"
-                onClick={(e) => e.stopPropagation()} // Stop click from bubbling to the backdrop (so it doesn't close)
-                className="bg-white dark:bg-gray-900 p-6 sm:rounded-2xl rounded-t-3xl shadow-xl w-full max-w-md transition-colors"
+                initial={{ y: '100%', opacity: 0.6, scale: 1 }}
+                animate={{ y: 0, opacity: 1, scale: 1 }}
+                exit={{ y: '100%', opacity: 0 }}
+                transition={{ type: 'spring', stiffness: 360, damping: 32 }}
+                onClick={(e) => e.stopPropagation()}
+                className="w-full max-w-md bg-white dark:bg-gray-900 rounded-t-3xl sm:rounded-3xl border border-gray-100 dark:border-gray-800 shadow-2xl p-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))] sm:pb-6"
             >
-                <h2 className={`text-3xl md:text-2xl font-bold mb-4 ${titleClass}`}>{title}</h2>
-                <h3 className="text-lg font-semibold text-gray-700 dark:text-gray-300">{location?.name}</h3>
+                {/* Grab handle (mobile bottom-sheet affordance) */}
+                <div className="sm:hidden mx-auto mb-5 h-1.5 w-10 rounded-full bg-gray-200 dark:bg-gray-700" />
 
-                <div className="flex justify-end space-x-3 mt-6">
-                    {!isSameLocation ? (
+                <div className="flex flex-col items-center text-center">
+                    <div className={`w-14 h-14 rounded-2xl flex items-center justify-center ${tint}`}>
+                        <VariantIcon weight="bold" className="w-7 h-7" />
+                    </div>
+                    <h2 className="text-title text-gray-900 dark:text-white mt-4">{title}</h2>
+                    <p className="text-micro text-gray-400 mt-3">{sub}</p>
+                    <p className="text-heading text-gray-900 dark:text-white mt-1">{locationName}</p>
+                </div>
+
+                <div className={`mt-7 ${isSame ? '' : 'flex gap-3'}`}>
+                    {isSame ? (
+                        <button
+                            type="button"
+                            onClick={onCancel}
+                            className="w-full py-4 rounded-2xl text-body-strong text-white bg-linear-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 shadow-lg shadow-emerald-500/25 active:scale-[0.98] transition-all"
+                        >
+                            Got it
+                        </button>
+                    ) : (
                         <>
                             <button
                                 type="button"
-                                onClick={handleCancel}
-                                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+                                onClick={onCancel}
+                                disabled={isBusy}
+                                className="flex-1 py-4 rounded-2xl text-body-strong text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 active:scale-[0.98] disabled:opacity-50 transition-all"
                             >
                                 Cancel
                             </button>
                             <button
                                 type="button"
-                                onClick={handleConfirm}
-                                disabled={isChangingLocation}
-                                className="px-4 py-2 text-sm font-medium text-white bg-emerald-600 rounded-md hover:bg-emerald-700 transition-colors shadow-sm cursor-pointer disabled:opacity-50"
+                                onClick={onConfirm}
+                                disabled={isBusy}
+                                className="flex-1 flex items-center justify-center gap-2 py-4 rounded-2xl text-body-strong text-white bg-linear-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 shadow-lg shadow-emerald-500/25 active:scale-[0.98] disabled:opacity-70 disabled:active:scale-100 transition-all"
                             >
-                                {isChangingLocation ? 'Updating...' : 'Yes'}
+                                {isBusy && <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />}
+                                {isBusy ? 'Saving…' : 'Confirm'}
                             </button>
                         </>
-                    ) : (
-                        <button
-                            type="button"
-                            onClick={handleCancel}
-                            className="px-4 py-2 text-sm font-medium text-white bg-emerald-600 rounded-md hover:bg-emerald-700 transition-colors shadow-sm cursor-pointer"
-                        >
-                            Got it
-                        </button>
                     )}
                 </div>
             </motion.div>

--- a/src/features/locations/hooks/useLocationManagement.ts
+++ b/src/features/locations/hooks/useLocationManagement.ts
@@ -34,7 +34,9 @@ export function useLocationManagement({
     // 1. Same location clicked
     if (locationId === selectedLocationId) {
       if (activeShift) {
-        setIsLocationPopupOpen(true); // Let them know they are already here.
+        // Let them know they're already here (popup needs the location to show).
+        setPendingLocation(locations.find((loc) => loc.id === locationId) ?? null);
+        setIsLocationPopupOpen(true);
       } else {
         setSelectedLocationId(null); // Deselect if no active shift.
       }


### PR DESCRIPTION
Redesigns the location confirm/switch popup so OK/Cancel are hard to mis-tap and it matches the app.

- Pure presentational **bottom sheet** (centered card on desktop): grab handle, icon, title, location name.
- Large full-width **Cancel / Confirm** buttons with a clear gap.
- Variant-aware: *Start here?* (pick) / *Move your shift?* (switch, amber) / *You're already here* (single Got it).
- Logic moved to AppShell (`confirmLocation`); `useLocationManagement` passes the location for the already-here case.

Re-done on current master after #74 hit conflicts with the parallel Requests/BottomNav work (LocationPopup wasn't touched there). Verified all 3 variants on mobile. typecheck/lint/test/build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)