### PR TITLE
feat(ui): compact location popup + top toast for 'already here'

### DIFF
--- a/src/app/layout/AppShell.tsx
+++ b/src/app/layout/AppShell.tsx
@@ -1,7 +1,7 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Outlet } from 'react-router-dom';
-import { WarningCircleIcon, XIcon } from '@phosphor-icons/react';
+import { WarningCircleIcon, XIcon, MapPinIcon } from '@phosphor-icons/react';
 
 import { useAuthContext } from '@features/auth/AuthContext';
 import { useShiftContext } from '@features/shifts/ShiftContext';
@@ -45,19 +45,23 @@ export function AppShell() {
     return () => clearTimeout(t);
   }, [actionError, clearActionError]);
 
+  // "You're already here" — a top push-style toast (auto-dismisses).
+  const [hereToast, setHereToast] = useState<string | null>(null);
+  useEffect(() => {
+    if (!hereToast) return;
+    const t = setTimeout(() => setHereToast(null), 3000);
+    return () => clearTimeout(t);
+  }, [hereToast]);
+
   // Location switch/confirm logic hook.
   const { isLocationPopupOpen, setIsLocationPopupOpen, pendingLocation, handleLocationSelect } = useLocationManagement({
     locations, activeShift, selectedLocationId, setSelectedLocationId,
+    onAlreadyHere: (name) => setHereToast(name),
   });
 
-  // What the location popup is asking, and what confirming does.
-  const popupVariant: LocationPopupVariant = !pendingLocation
-    ? 'confirm'
-    : pendingLocation.id === selectedLocationId
-      ? 'same'
-      : activeShift
-        ? 'switch'
-        : 'confirm';
+  // What the location popup is asking, and what confirming does. (The "already
+  // here" case never opens the popup — it shows the toast instead.)
+  const popupVariant: LocationPopupVariant = activeShift ? 'switch' : 'confirm';
 
   const confirmLocation = async () => {
     if (!pendingLocation) return;
@@ -119,6 +123,31 @@ export function AppShell() {
               <button onClick={clearActionError} aria-label="Dismiss" className="shrink-0 -m-1 p-1 hover:bg-white/20 rounded-lg transition-colors">
                 <XIcon weight="bold" className="w-4 h-4" />
               </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* "ALREADY HERE" TOAST — push-style, slides in from the top. */}
+      <AnimatePresence>
+        {hereToast && (
+          <motion.div
+            initial={{ opacity: 0, y: -24 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -24 }}
+            transition={{ type: 'spring', stiffness: 360, damping: 30 }}
+            role="status"
+            onClick={() => setHereToast(null)}
+            className="fixed left-1/2 -translate-x-1/2 z-[200] top-[calc(0.75rem+env(safe-area-inset-top))] w-[calc(100%-2rem)] max-w-sm"
+          >
+            <div className="flex items-center gap-3 bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 rounded-2xl px-4 py-3 shadow-2xl">
+              <div className="w-9 h-9 rounded-xl bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400 flex items-center justify-center shrink-0">
+                <MapPinIcon weight="fill" className="w-5 h-5" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-body-strong text-gray-900 dark:text-white leading-tight">You're already here</p>
+                <p className="text-caption text-gray-500 dark:text-gray-400 truncate">Working at {hereToast}</p>
+              </div>
             </div>
           </motion.div>
         )}

--- a/src/features/locations/components/LocationPopup.tsx
+++ b/src/features/locations/components/LocationPopup.tsx
@@ -1,15 +1,16 @@
 import { motion } from 'framer-motion';
-import { MapPinIcon, ArrowsLeftRightIcon, InfoIcon, type Icon } from '@phosphor-icons/react';
+import { MapPinIcon, ArrowsLeftRightIcon, type Icon } from '@phosphor-icons/react';
 
 /**
  * --- LOCATION POPUP ---
  * Confirms picking / switching a work location. Purely presentational — the
- * parent (AppShell) owns the state and the confirm action. Big, well-separated
- * buttons so OK / Cancel are hard to mis-tap on a phone, styled like the rest
- * of the app (bottom sheet on mobile, centered card on desktop).
+ * parent (AppShell) owns the state and the confirm action. Compact, left-aligned
+ * (the location name is the hero and fills the width), with full-width Cancel /
+ * Confirm buttons that are hard to mis-tap. Bottom sheet on mobile, centered card
+ * on desktop. (The "already here" case is a top toast, not this popup.)
  */
 
-export type LocationPopupVariant = 'confirm' | 'switch' | 'same';
+export type LocationPopupVariant = 'confirm' | 'switch';
 
 export interface LocationPopupProps {
     locationName: string;
@@ -19,30 +20,21 @@ export interface LocationPopupProps {
     onCancel: () => void;
 }
 
-const COPY: Record<LocationPopupVariant, { title: string; sub: string; icon: Icon; tint: string }> = {
+const COPY: Record<LocationPopupVariant, { sub: string; icon: Icon; tint: string }> = {
     confirm: {
-        title: 'Start here?',
-        sub: 'Set your location to',
+        sub: 'Start your shift at',
         icon: MapPinIcon,
         tint: 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400',
     },
     switch: {
-        title: 'Move your shift?',
-        sub: 'Change your location to',
+        sub: 'Move your shift to',
         icon: ArrowsLeftRightIcon,
         tint: 'bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400',
-    },
-    same: {
-        title: "You're already here",
-        sub: 'Your current location',
-        icon: InfoIcon,
-        tint: 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400',
     },
 };
 
 export function LocationPopup({ locationName, variant, isBusy, onConfirm, onCancel }: LocationPopupProps) {
-    const { title, sub, icon: VariantIcon, tint } = COPY[variant];
-    const isSame = variant === 'same';
+    const { sub, icon: VariantIcon, tint } = COPY[variant];
 
     return (
         <motion.div
@@ -54,55 +46,44 @@ export function LocationPopup({ locationName, variant, isBusy, onConfirm, onCanc
             onClick={onCancel}
         >
             <motion.div
-                initial={{ y: '100%', opacity: 0.6, scale: 1 }}
-                animate={{ y: 0, opacity: 1, scale: 1 }}
+                initial={{ y: '100%', opacity: 0.6 }}
+                animate={{ y: 0, opacity: 1 }}
                 exit={{ y: '100%', opacity: 0 }}
                 transition={{ type: 'spring', stiffness: 360, damping: 32 }}
                 onClick={(e) => e.stopPropagation()}
-                className="w-full max-w-md bg-white dark:bg-gray-900 rounded-t-3xl sm:rounded-3xl border border-gray-100 dark:border-gray-800 shadow-2xl p-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))] sm:pb-6"
+                className="w-full max-w-md bg-white dark:bg-gray-900 rounded-t-3xl sm:rounded-3xl border border-gray-100 dark:border-gray-800 shadow-2xl p-5 pb-[calc(1.25rem+env(safe-area-inset-bottom))] sm:pb-5"
             >
                 {/* Grab handle (mobile bottom-sheet affordance) */}
-                <div className="sm:hidden mx-auto mb-5 h-1.5 w-10 rounded-full bg-gray-200 dark:bg-gray-700" />
+                <div className="sm:hidden mx-auto mb-4 h-1.5 w-10 rounded-full bg-gray-200 dark:bg-gray-700" />
 
-                <div className="flex flex-col items-center text-center">
-                    <div className={`w-14 h-14 rounded-2xl flex items-center justify-center ${tint}`}>
-                        <VariantIcon weight="bold" className="w-7 h-7" />
+                <div className="flex items-center gap-3">
+                    <div className={`w-11 h-11 rounded-2xl flex items-center justify-center shrink-0 ${tint}`}>
+                        <VariantIcon weight="bold" className="w-5 h-5" />
                     </div>
-                    <h2 className="text-title text-gray-900 dark:text-white mt-4">{title}</h2>
-                    <p className="text-micro text-gray-400 mt-3">{sub}</p>
-                    <p className="text-heading text-gray-900 dark:text-white mt-1">{locationName}</p>
+                    <div className="min-w-0 flex-1">
+                        <p className="text-micro text-gray-400">{sub}</p>
+                        <p className="text-title text-gray-900 dark:text-white leading-snug truncate">{locationName}</p>
+                    </div>
                 </div>
 
-                <div className={`mt-7 ${isSame ? '' : 'flex gap-3'}`}>
-                    {isSame ? (
-                        <button
-                            type="button"
-                            onClick={onCancel}
-                            className="w-full py-4 rounded-2xl text-body-strong text-white bg-linear-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 shadow-lg shadow-emerald-500/25 active:scale-[0.98] transition-all"
-                        >
-                            Got it
-                        </button>
-                    ) : (
-                        <>
-                            <button
-                                type="button"
-                                onClick={onCancel}
-                                disabled={isBusy}
-                                className="flex-1 py-4 rounded-2xl text-body-strong text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 active:scale-[0.98] disabled:opacity-50 transition-all"
-                            >
-                                Cancel
-                            </button>
-                            <button
-                                type="button"
-                                onClick={onConfirm}
-                                disabled={isBusy}
-                                className="flex-1 flex items-center justify-center gap-2 py-4 rounded-2xl text-body-strong text-white bg-linear-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 shadow-lg shadow-emerald-500/25 active:scale-[0.98] disabled:opacity-70 disabled:active:scale-100 transition-all"
-                            >
-                                {isBusy && <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />}
-                                {isBusy ? 'Saving…' : 'Confirm'}
-                            </button>
-                        </>
-                    )}
+                <div className="mt-5 flex gap-3">
+                    <button
+                        type="button"
+                        onClick={onCancel}
+                        disabled={isBusy}
+                        className="flex-1 py-3.5 rounded-2xl text-body-strong text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 active:scale-[0.98] disabled:opacity-50 transition-all"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onConfirm}
+                        disabled={isBusy}
+                        className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-2xl text-body-strong text-white bg-linear-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 shadow-lg shadow-emerald-500/25 active:scale-[0.98] disabled:opacity-70 disabled:active:scale-100 transition-all"
+                    >
+                        {isBusy && <span className="w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />}
+                        {isBusy ? 'Saving…' : 'Confirm'}
+                    </button>
                 </div>
             </motion.div>
         </motion.div>

--- a/src/features/locations/hooks/useLocationManagement.ts
+++ b/src/features/locations/hooks/useLocationManagement.ts
@@ -15,6 +15,8 @@ interface UseLocationManagementProps {
   activeShift: Shift | null;
   selectedLocationId: string | null;
   setSelectedLocationId: (id: string | null) => void;
+  /** Tapped the location you're already working at — surfaced as a top toast. */
+  onAlreadyHere?: (locationName: string) => void;
 }
 
 
@@ -23,6 +25,7 @@ export function useLocationManagement({
   activeShift,
   selectedLocationId,
   setSelectedLocationId,
+  onAlreadyHere,
 }: UseLocationManagementProps) {
   const [isLocationPopupOpen, setIsLocationPopupOpen] = useState(false);
   const [pendingLocation, setPendingLocation] = useState<Location | null>(null);
@@ -34,9 +37,8 @@ export function useLocationManagement({
     // 1. Same location clicked
     if (locationId === selectedLocationId) {
       if (activeShift) {
-        // Let them know they're already here (popup needs the location to show).
-        setPendingLocation(locations.find((loc) => loc.id === locationId) ?? null);
-        setIsLocationPopupOpen(true);
+        // Already working here — a top toast (not a modal) just confirms it.
+        onAlreadyHere?.(locations.find((loc) => loc.id === locationId)?.name ?? '');
       } else {
         setSelectedLocationId(null); // Deselect if no active shift.
       }


### PR DESCRIPTION
Follow-up tweaks to the location popup.

- **Smaller & fills the width**: dropped the big centered title; now a small icon + eyebrow (*Start your shift at* / *Move your shift to*) with the **location name as the hero** (left-aligned, fills the horizontal space instead of centered with empty sides). More compact padding.
- **Buttons** stay as a full-width Cancel / Confirm row.
- **'Already here' is now a top toast**, not a modal — a push-notification-style banner that slides in from the top and auto-dismisses. `useLocationManagement` reports it via `onAlreadyHere`; AppShell renders it.

Verified on mobile + the centered card: compact popup with width-filling name, and the top toast. typecheck/lint/test/build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)